### PR TITLE
Feature/add weekend support #24

### DIFF
--- a/src/GeneratorPage/components/CalendarComponent.jsx
+++ b/src/GeneratorPage/components/CalendarComponent.jsx
@@ -56,6 +56,7 @@ export default function CalendarComponent({
     const [noCourses, setNoCourses] = useState(true);
     const [timeslotsOverridden, setTimeslotsOverridden] = useState(false);
     const [timeslotsOverriddenDialogOpen, setTimeslotsOverriddenDialogOpen] = useState(false);
+    const [showWeekends, setShowWeekends] = useState(false);
 
     useEffect(() => {
         const calendarElement = document.getElementById("Calendar");
@@ -162,6 +163,53 @@ export default function CalendarComponent({
         setCurrentTimetableIndex(timetables.length - 1);
     }, [timetables.length]);
 
+    // Check if any courses have weekend classes
+    const checkForWeekendClasses = useCallback((timetable) => {
+        if (!timetable || !timetable.courses) {
+            return false;
+        }
+        
+        for (const course of timetable.courses) {
+            const { mainComponents, secondaryComponents } = course;
+            
+            // Check main components
+            if (mainComponents) {
+                for (const component of mainComponents) {
+                    if (component.schedule.days && 
+                        (component.schedule.days.includes('S') || 
+                         component.schedule.days.includes('U'))) {
+                        return true;
+                    }
+                }
+            }
+            
+            // Check secondary components
+            if (secondaryComponents) {
+                const { lab, tutorial, seminar } = secondaryComponents;
+                
+                if (lab && lab.schedule.days && 
+                    (lab.schedule.days.includes('S') || 
+                     lab.schedule.days.includes('U'))) {
+                    return true;
+                }
+                
+                if (tutorial && tutorial.schedule.days && 
+                    (tutorial.schedule.days.includes('S') || 
+                     tutorial.schedule.days.includes('U'))) {
+                    return true;
+                }
+                
+                if (seminar && seminar.schedule.days && 
+                    (seminar.schedule.days.includes('S') || 
+                     seminar.schedule.days.includes('U'))) {
+                    return true;
+                }
+            }
+        }
+        
+        return false;
+    }, []);
+
     const updateCalendarEvents = useCallback(() => {
         const currentTimetables = timetablesRef.current;
         const currentIndex = currentTimetableIndexRef.current;
@@ -183,6 +231,11 @@ export default function CalendarComponent({
         if (currentTimetables.length > 0 && currentTimetables[0].courses.length > 0) {
             setNoCourses(false);
             const timetable = currentTimetables[currentIndex];
+            
+            // Check if any courses have weekend classes
+            const hasWeekendClasses = checkForWeekendClasses(timetable);
+            setShowWeekends(hasWeekendClasses);
+            
             if (previousDuration === selectedDuration.split("-")[2] && JSON.stringify(timetable)) {
                 aprioriDurationTimetable = JSON.parse(JSON.stringify(timetable));
             }
@@ -220,7 +273,7 @@ export default function CalendarComponent({
                 setNoTimetablesGenerated(true);
             }
         }
-    }, [getDefaultColorForCourse, enqueueSnackbar, setCourseDetails, setEvents, setNoCourses, setNoTimetablesGenerated, handleLast]);
+    }, [getDefaultColorForCourse, enqueueSnackbar, setCourseDetails, setEvents, setNoCourses, setNoTimetablesGenerated, handleLast, checkForWeekendClasses]);
 
 const handleCalendarViewClick = (durationLabel) => {
     const calendarApi = calendarRef.current.getApi();
@@ -566,7 +619,7 @@ const handleCalendarViewClick = (durationLabel) => {
                 ref={calendarRef}
                 plugins={[timeGridPlugin, interactionPlugin]}
                 initialView="timeGridWeek"
-                weekends={false}
+                weekends={showWeekends}
                 headerToolbar={false}
                 height={835}
                 dayHeaderFormat={{ weekday: "short" }}

--- a/src/GeneratorPage/components/CalendarComponent.jsx
+++ b/src/GeneratorPage/components/CalendarComponent.jsx
@@ -423,6 +423,8 @@ const handleCalendarViewClick = (durationLabel) => {
             Wed: "W",
             Thu: "R",
             Fri: "F",
+            Sat: "S",
+            Sun: "U",
         };
 
         // Get all days between start and end date

--- a/src/GeneratorPage/components/CalendarComponent.jsx
+++ b/src/GeneratorPage/components/CalendarComponent.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext, useCallback } from "react";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
+import dayGridPlugin from "@fullcalendar/daygrid";
 import BlockIcon from "@mui/icons-material/Block";
 import PinIcon from "@mui/icons-material/PushPin";
 import { useTheme } from "@mui/material/styles";
@@ -278,7 +279,13 @@ export default function CalendarComponent({
 const handleCalendarViewClick = (durationLabel) => {
     const calendarApi = calendarRef.current.getApi();
     const [startUnix, endUnix, duration] = durationLabel.split("-");
-
+    
+    // Convert Unix timestamps to dates
+    const startDate = new Date(parseInt(startUnix) * 1000);
+    
+    // Navigate to the start date
+    calendarApi.gotoDate(startDate);
+    
     if (previousDuration == null) {
         previousDuration = duration;
     } else if (previousDuration !== duration) {
@@ -328,23 +335,16 @@ const handleCalendarViewClick = (durationLabel) => {
         }
     }
     
-        const startDate = new Date(startUnix * 1000);
-
-        if (startDate.getDay() != 1) {
-            startDate.setDate(startDate.getDate() + 7);
+    setSelectedDuration(durationLabel);
+    enqueueSnackbar(
+        <MultiLineSnackbar
+            message={"Calendar View: " + startDate.toLocaleString("default", { month: "long", year: "numeric" })}
+        />,
+        {
+            variant: "info",
         }
-
-        calendarApi.gotoDate(startDate);
-        setSelectedDuration(durationLabel);
-        enqueueSnackbar(
-            <MultiLineSnackbar
-                message={"Calendar View: " + startDate.toLocaleString("default", { month: "long", year: "numeric" })}
-            />,
-            {
-                variant: "info",
-            }
-        );
-    };
+    );
+};
 
     const handleEventClick = (clickInfo) => {
         if (!clickInfo.event.extendedProps.isBlocked) {
@@ -424,7 +424,7 @@ const handleCalendarViewClick = (durationLabel) => {
             Thu: "R",
             Fri: "F",
             Sat: "S",
-            Sun: "U",
+            Sun: "U"
         };
 
         // Get all days between start and end date
@@ -626,8 +626,6 @@ const handleCalendarViewClick = (durationLabel) => {
                 height={835}
                 dayHeaderFormat={{ weekday: "short" }}
                 dayCellClassNames={(arg) => (arg.date.getDay() === new Date().getDay() ? "fc-day-today" : "")}
-                initialDate="2024-09-10"
-                events={events}
                 slotMinTime="08:00:00"
                 slotMaxTime="23:00:00"
                 slotDuration="00:30:00"
@@ -641,6 +639,8 @@ const handleCalendarViewClick = (durationLabel) => {
                 selectAllow={handleSelectAllow}
                 longPressDelay={0}
                 selectLongPressDelay={500}
+                firstDay={1}
+                events={events}
             />
             <TruncationDialog
                 truncationDialogOpen={truncationDialogOpen}

--- a/src/GeneratorPage/components/CalendarComponent.jsx
+++ b/src/GeneratorPage/components/CalendarComponent.jsx
@@ -356,17 +356,17 @@ const handleCalendarViewClick = (durationLabel) => {
 
             const pinnedComponents = getPinnedComponents();
             /*
-            NOTE: substring(0,7) is used as ID's are 7 characters long.
+            NOTE: substring(0,6) is used as ID's are 6 characters long.
 
             If there are multiple main components (such as two LECs) the 
             additional main components will have and index counter extension
             which is what the substring is trying to strip for the purpose
             of pinning.
             */
-            if (pinnedComponents.includes(courseCode + " " + split[1] + " " + clickInfo.event.id.substring(0, 7))) {
-                removePinnedComponent(courseCode + " " + split[1] + " " + clickInfo.event.id.substring(0, 7));
+            if (pinnedComponents.includes(courseCode + " " + split[1] + " " + clickInfo.event.id.substring(0, 6))) {
+                removePinnedComponent(courseCode + " " + split[1] + " " + clickInfo.event.id.substring(0, 6));
             } else {
-                addPinnedComponent(courseCode + " " + split[1] + " " + clickInfo.event.id.substring(0, 7));
+                addPinnedComponent(courseCode + " " + split[1] + " " + clickInfo.event.id.substring(0, 6));
             }
         } else {
             const blockId = clickInfo.event.id.replace('block-', '');

--- a/src/GeneratorPage/components/InputFormComponents/TermSelectComponent.jsx
+++ b/src/GeneratorPage/components/InputFormComponents/TermSelectComponent.jsx
@@ -28,7 +28,7 @@ export default function TermSelectComponent({ onTermChange }) {
             onChange={handleTermChange}
           >
             <MenuItem value={''}>Select Term</MenuItem>
-            <MenuItem disabled={false} value={'FW'}>Fall/Winter</MenuItem>
+            <MenuItem disabled={true} value={'FW'}>Fall/Winter</MenuItem>
             <MenuItem disabled={false} value={'SP'}>Spring 2025</MenuItem>
             <MenuItem disabled={false} value={'SU'}>Summer 2025</MenuItem>
           </Select>

--- a/src/GeneratorPage/components/InputFormComponents/TermSelectComponent.jsx
+++ b/src/GeneratorPage/components/InputFormComponents/TermSelectComponent.jsx
@@ -28,7 +28,7 @@ export default function TermSelectComponent({ onTermChange }) {
             onChange={handleTermChange}
           >
             <MenuItem value={''}>Select Term</MenuItem>
-            <MenuItem disabled={true} value={'FW'}>Fall/Winter</MenuItem>
+            <MenuItem disabled={false} value={'FW'}>Fall/Winter</MenuItem>
             <MenuItem disabled={false} value={'SP'}>Spring 2025</MenuItem>
             <MenuItem disabled={false} value={'SU'}>Summer 2025</MenuItem>
           </Select>

--- a/src/GeneratorPage/scripts/__tests__/timeSlotConflicts.test.js
+++ b/src/GeneratorPage/scripts/__tests__/timeSlotConflicts.test.js
@@ -26,7 +26,9 @@ describe('Time Slot Conflict Handling', () => {
             T: Array(28).fill(false),
             W: Array(28).fill(false),
             R: Array(28).fill(false),
-            F: Array(28).fill(false)
+            F: Array(28).fill(false),
+            S: Array(28).fill(false),
+            U: Array(28).fill(false)
         };
         getTimeSlots.mockReturnValue(emptyTimeSlots);
         getPinnedComponents.mockReturnValue([]);
@@ -209,7 +211,9 @@ describe('Time Slot Conflict Handling', () => {
             T: Array(28).fill(false),
             W: Array(28).fill(false).map((_, i) => i < 4),
             R: Array(28).fill(false),
-            F: Array(28).fill(false)
+            F: Array(28).fill(false),
+            S: Array(28).fill(false),
+            U: Array(28).fill(false)
         };
         getTimeSlots.mockReturnValue(blockedTimeSlots);
 
@@ -223,5 +227,46 @@ describe('Time Slot Conflict Handling', () => {
             expect(section.id).toBe('2');
             expect(section.schedule.time).toBe('1000-1130');
         });
+    });
+
+    it('should handle weekend time slots correctly', () => {
+        const mockCourseData = {
+            'COSC 1P02': {
+                courseCode: 'COSC 1P02',
+                sections: [
+                    {
+                        id: '1',
+                        schedule: {
+                            days: 'S U',
+                            time: '0800-0930',
+                            duration: 'D2',
+                            startDate: 1,
+                            endDate: 60
+                        }
+                    }
+                ],
+                labs: [],
+                tutorials: [],
+                seminars: []
+            }
+        };
+        getCourseData.mockReturnValue(mockCourseData);
+
+        const blockedTimeSlots = {
+            M: Array(28).fill(false),
+            T: Array(28).fill(false),
+            W: Array(28).fill(false),
+            R: Array(28).fill(false),
+            F: Array(28).fill(false),
+            S: Array(28).fill(false).map((_, i) => i < 4),
+            U: Array(28).fill(false)
+        };
+        getTimeSlots.mockReturnValue(blockedTimeSlots);
+
+        generateTimetables();
+        const timetables = getValidTimetables();
+
+        expect(timetables.length).toBeGreaterThan(0);
+        expect(timetables[0].courses[0].mainComponents[0].schedule.days).toBe('S U');
     });
 }); 

--- a/src/GeneratorPage/scripts/timeSlots.js
+++ b/src/GeneratorPage/scripts/timeSlots.js
@@ -1,5 +1,5 @@
 /*
-NOTE: This code manages the availability of time slots for a weekly schedule (Monday to Friday) between 8 AM and 10 PM.
+NOTE: This code manages the availability of time slots for a weekly schedule (Monday to Sunday) between 8 AM and 10 PM.
 
 The timeSlots object is a JavaScript object where each key (representing a day, like 'M' for Monday) maps to a 1D array. 
 Each array contains boolean values indicating whether a time slot is open (false) or blocked (true).
@@ -7,7 +7,7 @@ Each array contains boolean values indicating whether a time slot is open (false
 let timeSlots = {};
 
 const initializeTimeSlots = () => {
-    const days = ['M', 'T', 'W', 'R', 'F'];
+    const days = ['M', 'T', 'W', 'R', 'F', 'S', 'U'];
     const slotsPerDay = (22 - 8) * 2; // Each hour has 2 slots (30 minutes each)
 
     days.forEach(day => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/7decc9b7-ef0d-4cd7-aa8e-e031cd8e6ce4

adds weekend course support 
- show weekends on calendar (when applicable)
    - start on monday to ensure wednesday-sunday courses show up properly
- add support for weekend courses (previously only handled weekday courses