### PR TITLE
Update NavbarComponent to reflect new branding and remove unused imports

### DIFF
--- a/src/SiteWide/components/NavbarComponent.jsx
+++ b/src/SiteWide/components/NavbarComponent.jsx
@@ -1,7 +1,6 @@
 import React, { useContext, useState } from "react";
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
-import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
 import Brightness4Icon from "@mui/icons-material/Brightness4";
@@ -12,18 +11,13 @@ import { Link } from "react-router-dom";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import Drawer from "@mui/material/Drawer";
 import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import { ListItemButton, Divider, Avatar, ListItemIcon } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 // Import additional icons
 import HomeIcon from "@mui/icons-material/Home";
 import MenuBookIcon from "@mui/icons-material/MenuBook";
-import InfoIcon from "@mui/icons-material/Info";
 import FeedbackIcon from "@mui/icons-material/Feedback";
-import AddIcon from "@mui/icons-material/Add";
-import SaveIcon from "@mui/icons-material/Save";
-import SettingsIcon from "@mui/icons-material/Settings";
 import GitHubIcon from "@mui/icons-material/GitHub";
 
 const NavbarComponent = () => {
@@ -51,7 +45,7 @@ const NavbarComponent = () => {
     >
       <Box sx={{ p: 3, borderBottom: `1px solid ${theme.palette.divider}` }}>
         <Typography variant="h6" component="div" sx={{ fontWeight: "bold" }}>
-          📚 Brock Visual TimeTable
+          📚 brocktimetable.com
         </Typography>
       </Box>
 
@@ -135,7 +129,7 @@ const NavbarComponent = () => {
           component="div"
           sx={{ fontWeight: "bold" }}
         >
-          📚 Brock Visual TimeTable
+          📚 brocktimetable.com
         </Typography>
         {isMobile ? (
           <>


### PR DESCRIPTION
Closes https://github.com/BrockTimetable/BrockVisualTimetable/issues/50

This pull request includes updates to the `NavbarComponent.jsx` file to simplify the codebase and make branding changes. The most important changes involve removing unused imports, updating the displayed branding text, and cleaning up the code structure.

### Codebase simplification:
* Removed unused imports such as `Toolbar`, `ListItem`, `InfoIcon`, `AddIcon`, `SaveIcon`, and `SettingsIcon` to streamline the component. 

### Branding updates:
* Updated the branding text from "📚 Brock Visual TimeTable" to "📚 brocktimetable.com" in two places within the `NavbarComponent`. 

|Before|After|
|-|-|
|<img width="1497" height="844" alt="image" src="https://github.com/user-attachments/assets/9066ba84-3b85-4d6e-9b21-88346c285f54" />|<img width="1497" height="844" alt="image" src="https://github.com/user-attachments/assets/25159c88-785a-4a55-82eb-50ea2e98bf7d" />|
|<img width="499" height="775" alt="image" src="https://github.com/user-attachments/assets/63a0f83f-672a-4392-b13b-22d0dbc2f38a" />|<img width="499" height="775" alt="image" src="https://github.com/user-attachments/assets/99383c8d-c6a2-47d5-9b16-d5112d1db1b8" />|
|<img width="499" height="775" alt="image" src="https://github.com/user-attachments/assets/c282354c-a070-4843-bc1a-811fed057159" />|<img width="499" height="775" alt="image" src="https://github.com/user-attachments/assets/aad0f094-70d8-4e38-a5dd-b489e3fda81a" />|