### PR TITLE
Add Blocked Slot Renaming

### DIFF
--- a/src/GeneratorPage/components/Calendar/CalendarComponent.jsx
+++ b/src/GeneratorPage/components/Calendar/CalendarComponent.jsx
@@ -230,6 +230,86 @@ export default function CalendarComponent({
     });
   };
 
+  const [shiftHeld, setShiftHeld] = useState(false);
+  const [hoveredElement, setHoveredElement] = useState(null);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === "Shift") {
+        setShiftHeld(true);
+      }
+    };
+
+    const handleKeyUp = (event) => {
+      if (event.key === "Shift") {
+        setShiftHeld(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (hoveredElement) {
+      const event = hoveredElement._fcEvent;
+      if (event && event.extendedProps && event.extendedProps.isBlocked) {
+        if (shiftHeld) {
+          hoveredElement.style.setProperty("cursor", "text", "important");
+          hoveredElement.classList.add("rename-mode");
+
+          const eventMain = hoveredElement.querySelector(".fc-event-main");
+          if (eventMain) {
+            eventMain.style.setProperty("cursor", "text", "important");
+          }
+        } else {
+          hoveredElement.style.removeProperty("cursor");
+          hoveredElement.classList.remove("rename-mode");
+
+          const eventMain = hoveredElement.querySelector(".fc-event-main");
+          if (eventMain) {
+            eventMain.style.removeProperty("cursor");
+          }
+        }
+      }
+    }
+  }, [shiftHeld, hoveredElement]);
+
+  const handleEventMouseEnter = (mouseEnterInfo) => {
+    setHoveredElement(mouseEnterInfo.el);
+    mouseEnterInfo.el._fcEvent = mouseEnterInfo.event;
+
+    if (mouseEnterInfo.event.extendedProps.isBlocked) {
+      if (shiftHeld) {
+        mouseEnterInfo.el.style.setProperty("cursor", "text", "important");
+        mouseEnterInfo.el.classList.add("rename-mode");
+
+        const eventMain = mouseEnterInfo.el.querySelector(".fc-event-main");
+        if (eventMain) {
+          eventMain.style.setProperty("cursor", "text", "important");
+        }
+      }
+    }
+  };
+
+  const handleEventMouseLeave = (mouseLeaveInfo) => {
+    setHoveredElement(null);
+    delete mouseLeaveInfo.el._fcEvent;
+
+    mouseLeaveInfo.el.style.removeProperty("cursor");
+    mouseLeaveInfo.el.classList.remove("rename-mode");
+
+    const eventMain = mouseLeaveInfo.el.querySelector(".fc-event-main");
+    if (eventMain) {
+      eventMain.style.removeProperty("cursor");
+    }
+  };
+
   const handleEventClick = (clickInfo) => {
     // Handle shift+click for quick rename
     if (clickInfo.jsEvent && clickInfo.jsEvent.shiftKey) {
@@ -401,6 +481,8 @@ export default function CalendarComponent({
             handleEventClick,
             handleSelect,
             handleSelectAllow,
+            handleEventMouseEnter,
+            handleEventMouseLeave,
           })}
         />
 

--- a/src/GeneratorPage/components/Calendar/utils/calendarConfigUtils.js
+++ b/src/GeneratorPage/components/Calendar/utils/calendarConfigUtils.js
@@ -9,6 +9,8 @@ export const getFullCalendarConfig = ({
   handleEventClick,
   handleSelect,
   handleSelectAllow,
+  handleEventMouseEnter,
+  handleEventMouseLeave,
 }) => ({
   ref: calendarRef,
   plugins: [timeGridPlugin, interactionPlugin],
@@ -26,6 +28,8 @@ export const getFullCalendarConfig = ({
   allDayText: "ONLINE",
   eventContent: renderEventContent,
   eventClick: handleEventClick,
+  eventMouseEnter: handleEventMouseEnter,
+  eventMouseLeave: handleEventMouseLeave,
   selectable: true,
   selectMinDistance: 25,
   select: handleSelect,

--- a/src/GeneratorPage/components/Calendar/utils/calendarUtils.jsx
+++ b/src/GeneratorPage/components/Calendar/utils/calendarUtils.jsx
@@ -15,13 +15,26 @@ export const renderEventContent = (eventInfo) => {
   const minDurationToShowTime = 90;
 
   if (eventInfo.event.extendedProps.isBlocked) {
+    const blockTitle = eventInfo.event.title || "";
+    const truncatedTitle =
+      blockTitle.length > 25 ? `${blockTitle.substring(0, 25)}...` : blockTitle;
+
     return (
       <div
         style={{ position: "relative", height: "100%", textAlign: "center" }}
       >
         {eventDuration >= minDurationToShowTime && (
-          <div style={{ position: "absolute", top: "2px", left: "2px" }}>
+          <div
+            style={{
+              position: "absolute",
+              top: "2px",
+              left: "2px",
+              textAlign: "left",
+            }}
+          >
             <b>{eventInfo.timeText}</b>
+            <br />
+            <span style={{}}>{truncatedTitle}</span>
           </div>
         )}
         <div

--- a/src/GeneratorPage/components/Dialogs/RenameBlockedSlotDialog.jsx
+++ b/src/GeneratorPage/components/Dialogs/RenameBlockedSlotDialog.jsx
@@ -139,10 +139,14 @@ export default function RenameBlockedSlotDialog({
     <Popover
       open={open}
       anchorEl={forceAnchorPosition ? null : anchorEl}
-      anchorPosition={
-        forceAnchorPosition ||
-        (anchorEl ? undefined : { top: 100, left: window.innerWidth / 2 })
-      }
+      {...(forceAnchorPosition || !anchorEl
+        ? {
+            anchorPosition: forceAnchorPosition || {
+              top: 100,
+              left: window.innerWidth / 2,
+            },
+          }
+        : {})}
       onClose={handleClose}
       anchorOrigin={{
         vertical: "bottom",
@@ -153,7 +157,11 @@ export default function RenameBlockedSlotDialog({
         horizontal: "center",
       }}
       anchorReference={
-        forceAnchorPosition || anchorEl ? "anchorPosition" : "anchorEl"
+        forceAnchorPosition
+          ? "anchorPosition"
+          : anchorEl
+            ? "anchorEl"
+            : "anchorPosition"
       }
       sx={{
         "& .MuiPopover-paper": {

--- a/src/GeneratorPage/components/Dialogs/RenameBlockedSlotDialog.jsx
+++ b/src/GeneratorPage/components/Dialogs/RenameBlockedSlotDialog.jsx
@@ -8,6 +8,8 @@ import {
   TextField,
   Box,
   Typography,
+  useTheme,
+  useMediaQuery,
 } from "@mui/material";
 
 export default function RenameBlockedSlotDialog({
@@ -19,13 +21,13 @@ export default function RenameBlockedSlotDialog({
   isMultipleBlocks = false,
   anchorEl,
   anchorPosition,
-  forceAnchorPosition, // New prop for forced positioning
+  forceAnchorPosition,
 }) {
   const [title, setTitle] = useState(currentTitle);
   const [error, setError] = useState("");
 
-  // Simple mobile detection
-  const isMobile = window.innerWidth <= 768;
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
     setTitle(currentTitle);
@@ -35,7 +37,6 @@ export default function RenameBlockedSlotDialog({
   const handleSave = () => {
     const trimmedTitle = title.trim();
 
-    // Validation - only check length, allow empty titles
     if (trimmedTitle.length > 50) {
       setError("Title must be 50 characters or less");
       return;
@@ -58,25 +59,25 @@ export default function RenameBlockedSlotDialog({
   };
 
   const dialogContent = (
-    <Box sx={{ minWidth: 200 }}>
-      <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+    <Box sx={{ minWidth: 180 }}>
+      <Typography
+        variant="h6"
+        sx={{ mb: 1, fontWeight: 600, fontSize: "1.1rem" }}
+      >
         {isCreating
           ? isMultipleBlocks
-            ? "Name Your Blocked Times"
-            : "Name Your Blocked Time"
+            ? "Name Blocked Times"
+            : "Name Blocked Time"
           : isMultipleBlocks
-            ? "Rename Blocked Times"
-            : "Rename Blocked Time"}
+            ? "Rename Times"
+            : "Rename Time"}
       </Typography>
 
-      <Typography variant="body2" sx={{ mb: 3, color: "text.secondary" }}>
-        {isCreating
-          ? isMultipleBlocks
-            ? "Give these blocked time slots a name to help you remember what they're for."
-            : "Give this blocked time slot a name to help you remember what it's for."
-          : isMultipleBlocks
-            ? "Update the name for these blocked time slots."
-            : "Update the name for this blocked time slot."}
+      <Typography
+        variant="body2"
+        sx={{ mb: 2, color: "text.secondary", fontSize: "0.875rem" }}
+      >
+        {isMultipleBlocks ? "Label these time slots" : "Label this time slot"}
       </Typography>
 
       <TextField
@@ -92,18 +93,18 @@ export default function RenameBlockedSlotDialog({
         }}
         onKeyPress={handleKeyPress}
         error={!!error}
-        helperText={error || "Optional - e.g., Work, Gym, Study, Meeting"}
+        helperText={error || "e.g., Work, Gym"}
         inputProps={{
           maxLength: 50,
         }}
-        sx={{ mb: 3 }}
+        sx={{ mb: 2 }}
       />
 
       <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
         <Button
           onClick={handleClose}
           size="small"
-          sx={{ color: "text.secondary" }}
+          sx={{ color: "text.secondary", minWidth: 60 }}
         >
           Cancel
         </Button>
@@ -111,9 +112,9 @@ export default function RenameBlockedSlotDialog({
           onClick={handleSave}
           variant="contained"
           size="small"
-          sx={{ minWidth: 80 }}
+          sx={{ minWidth: 60 }}
         >
-          {isCreating ? "Create Block" : "Save"}
+          {isCreating ? "Create" : "Save"}
         </Button>
       </Box>
     </Box>
@@ -133,7 +134,7 @@ export default function RenameBlockedSlotDialog({
         },
       }}
     >
-      <DialogContent sx={{ p: 3 }}>{dialogContent}</DialogContent>
+      <DialogContent sx={{ p: 2 }}>{dialogContent}</DialogContent>
     </Dialog>
   ) : (
     <Popover
@@ -168,7 +169,7 @@ export default function RenameBlockedSlotDialog({
           borderRadius: 2,
           boxShadow: "0 8px 32px rgba(0,0,0,0.12)",
           border: "1px solid rgba(0,0,0,0.08)",
-          p: 3,
+          p: 2,
         },
       }}
     >

--- a/src/GeneratorPage/components/Dialogs/RenameBlockedSlotDialog.jsx
+++ b/src/GeneratorPage/components/Dialogs/RenameBlockedSlotDialog.jsx
@@ -1,0 +1,170 @@
+import React, { useState, useEffect } from "react";
+import {
+  Popover,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Button,
+  TextField,
+  Box,
+  Typography,
+} from "@mui/material";
+
+export default function RenameBlockedSlotDialog({
+  open,
+  onClose,
+  onSave,
+  currentTitle = "",
+  isCreating = false,
+  isMultipleBlocks = false,
+  anchorEl,
+  anchorPosition,
+  forceAnchorPosition, // New prop for forced positioning
+}) {
+  const [title, setTitle] = useState(currentTitle);
+  const [error, setError] = useState("");
+
+  // Simple mobile detection
+  const isMobile = window.innerWidth <= 768;
+
+  useEffect(() => {
+    setTitle(currentTitle);
+    setError("");
+  }, [currentTitle, open]);
+
+  const handleSave = () => {
+    const trimmedTitle = title.trim();
+
+    // Validation - only check length, allow empty titles
+    if (trimmedTitle.length > 50) {
+      setError("Title must be 50 characters or less");
+      return;
+    }
+
+    onSave(trimmedTitle);
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setTitle(currentTitle);
+    setError("");
+    onClose();
+  };
+
+  const handleKeyPress = (event) => {
+    if (event.key === "Enter") {
+      handleSave();
+    }
+  };
+
+  const dialogContent = (
+    <Box sx={{ minWidth: 200 }}>
+      <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+        {isCreating
+          ? isMultipleBlocks
+            ? "Name Your Blocked Times"
+            : "Name Your Blocked Time"
+          : isMultipleBlocks
+            ? "Rename Blocked Times"
+            : "Rename Blocked Time"}
+      </Typography>
+
+      <Typography variant="body2" sx={{ mb: 3, color: "text.secondary" }}>
+        {isCreating
+          ? isMultipleBlocks
+            ? "Give these blocked time slots a name to help you remember what they're for."
+            : "Give this blocked time slot a name to help you remember what it's for."
+          : isMultipleBlocks
+            ? "Update the name for these blocked time slots."
+            : "Update the name for this blocked time slot."}
+      </Typography>
+
+      <TextField
+        autoFocus={!isMobile}
+        fullWidth
+        label="Block Name"
+        variant="outlined"
+        size="small"
+        value={title}
+        onChange={(e) => {
+          setTitle(e.target.value);
+          if (error) setError("");
+        }}
+        onKeyPress={handleKeyPress}
+        error={!!error}
+        helperText={error || "Optional - e.g., Work, Gym, Study, Meeting"}
+        inputProps={{
+          maxLength: 50,
+        }}
+        sx={{ mb: 3 }}
+      />
+
+      <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+        <Button
+          onClick={handleClose}
+          size="small"
+          sx={{ color: "text.secondary" }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          size="small"
+          sx={{ minWidth: 80 }}
+        >
+          {isCreating ? "Create Block" : "Save"}
+        </Button>
+      </Box>
+    </Box>
+  );
+
+  return isMobile ? (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      sx={{
+        "& .MuiDialog-paper": {
+          borderRadius: 2,
+          boxShadow: "0 8px 32px rgba(0,0,0,0.12)",
+          border: "1px solid rgba(0,0,0,0.08)",
+        },
+      }}
+    >
+      <DialogContent sx={{ p: 3 }}>{dialogContent}</DialogContent>
+    </Dialog>
+  ) : (
+    <Popover
+      open={open}
+      anchorEl={forceAnchorPosition ? null : anchorEl}
+      anchorPosition={
+        forceAnchorPosition ||
+        (anchorEl ? undefined : { top: 100, left: window.innerWidth / 2 })
+      }
+      onClose={handleClose}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "center",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "center",
+      }}
+      anchorReference={
+        forceAnchorPosition || anchorEl ? "anchorPosition" : "anchorEl"
+      }
+      sx={{
+        "& .MuiPopover-paper": {
+          borderRadius: 2,
+          boxShadow: "0 8px 32px rgba(0,0,0,0.12)",
+          border: "1px solid rgba(0,0,0,0.08)",
+          p: 3,
+        },
+      }}
+    >
+      {dialogContent}
+    </Popover>
+  );
+}

--- a/src/GeneratorPage/css/CustomCalendar.css
+++ b/src/GeneratorPage/css/CustomCalendar.css
@@ -59,6 +59,12 @@ body.dark-mode .fc-event {
   cursor: pointer;
 }
 
+.fc-timegrid-event.rename-mode,
+.fc-timegrid-event.rename-mode .fc-event-main,
+.fc-timegrid-event.rename-mode * {
+  cursor: text !important;
+}
+
 .fc-timegrid-event .fc-event-main {
   padding: 0;
 }

--- a/src/GeneratorPage/scripts/createCalendarEvents.js
+++ b/src/GeneratorPage/scripts/createCalendarEvents.js
@@ -33,7 +33,11 @@ export const createCalendarEvents = (
     const customColor = courseColors[course.courseCode] || defaultColor;
     const event = {
       id: uniqueId,
-      title: `${course.courseCode} ${component.type} ${/^\d+$/.test(component.sectionNumber) ? ` ${component.sectionNumber}` : ""}`,
+      title: `${course.courseCode} ${component.type} ${
+        /^\d+$/.test(component.sectionNumber)
+          ? ` ${component.sectionNumber}`
+          : ""
+      }`,
       daysOfWeek: getDaysOfWeek(component.schedule.days || "M T W R F"),
       startRecur: formatDate(component.schedule.startDate, false),
       endRecur: formatDate(component.schedule.endDate, true),
@@ -77,6 +81,7 @@ export const createCalendarEvents = (
   const addTimeBlockEvent = (block) => {
     newEvents.push({
       id: `block-${block.id}`,
+      title: block.title || "",
       daysOfWeek: getDaysOfWeek(block.daysOfWeek),
       startTime: block.startTime,
       endTime: block.endTime,
@@ -285,6 +290,13 @@ export const addTimeBlockEvent = (block) => {
 
 export const removeTimeBlockEvent = (blockId) => {
   timeBlockEvents = timeBlockEvents.filter((block) => block.id !== blockId);
+};
+
+export const updateTimeBlockEventTitle = (blockId, newTitle) => {
+  const blockIndex = timeBlockEvents.findIndex((block) => block.id === blockId);
+  if (blockIndex !== -1) {
+    timeBlockEvents[blockIndex].title = newTitle || "";
+  }
 };
 
 export const isEventPinned = (event) => {


### PR DESCRIPTION
Closes #52 

## What
Adds the ability to rename blocked time slots in the calendar.

## Why
- No way to rename existing blocked time slots
- Right-click and long-press functionality wasn't working

## How
- **Desktop**: `Shift + Click` on blocked slots to rename
- **Mobile**: Full-screen Dialog
- **Responsive**: Switches between Dialog/Popover based on screen size

## Files Changed
- `RenameBlockedSlotDialog.jsx` (NEW) - Main responsive component
- `CalendarComponent.jsx` - Integration and event handling
- `eventHandlerUtils.js` - Positioning logic
- `calendarUtils.jsx` - Utility enhancements
- `createCalendarEvents.js` - Event creation updates

## Demo

https://github.com/user-attachments/assets/390398af-a00a-412b-ac34-1d047df2864e

https://github.com/user-attachments/assets/0f0247a6-be43-48f9-8425-9fdf981e1cbb

https://github.com/user-attachments/assets/34d7dd82-f35d-4023-88f2-406816823c1f




