### PR TITLE
fix: list items peeking behind/above list categories

### DIFF
--- a/src/GeneratorPage/components/Forms/CourseSearch/CourseSearchComponent.jsx
+++ b/src/GeneratorPage/components/Forms/CourseSearch/CourseSearchComponent.jsx
@@ -4,8 +4,19 @@ import "../../../css/DepartmentSearch.css";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
-import FormHelperText from "@mui/material/FormHelperText";
-import ListSubheader from "@mui/material/ListSubheader";
+import { styled } from "@mui/material";
+
+const GroupHeader = styled("div")(({ theme }) => ({
+  position: "sticky",
+  top: "-8px",
+  padding: "4px 10px",
+  color: theme.palette.primary.contrastText,
+  backgroundColor: theme.palette.primary.main,
+}));
+
+const GroupItems = styled("ul")({
+  padding: 0,
+});
 
 export default function CourseSearchComponent({
   onCourseCodeChange,
@@ -29,44 +40,32 @@ export default function CourseSearchComponent({
   return (
     <Box>
       <Autocomplete
-        disablePortal
-        freeSolo
-        fullWidth
+        options={courseOptions}
+        groupBy={(option) => option.slice(0, 4).toUpperCase()}
+        getOptionLabel={(option) => option}
+        sx={{ width: 300 }}
         onInputChange={(event, newInputValue) => {
           setInputValue(newInputValue);
           courseCodeChangeHandler(event, newInputValue);
         }}
         inputValue={inputValue}
-        options={courseOptions}
         filterOptions={filterOptions}
-        groupBy={(option) => option.slice(0, 4).toUpperCase()}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Add a course"
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                onEnterPress(event);
+              }
+            }}
+          />
+        )}
         renderGroup={(params) => (
           <li key={params.key}>
-            <ListSubheader
-              sx={{
-                backgroundColor: "primary.main",
-                color: "white",
-                fontSize: "1rem",
-                lineHeight: "2",
-              }}
-            >
-              {params.group}
-            </ListSubheader>
-            {params.children}
+            <GroupHeader>{params.group}</GroupHeader>
+            <GroupItems>{params.children}</GroupItems>
           </li>
-        )}
-        renderInput={(params) => (
-          <>
-            <TextField
-              {...params}
-              label="Add a course"
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  onEnterPress(event);
-                }
-              }}
-            />
-          </>
         )}
       />
     </Box>


### PR DESCRIPTION
Closes #56 

This pull request refactors the grouping and styling logic for course options in the `CourseSearchComponent`. The main changes involve replacing MUI's `ListSubheader` with custom-styled components for group headers and items, leading to improved visual consistency and maintainability.

**Styling and UI improvements:**

* Introduced two custom-styled components, `GroupHeader` and `GroupItems`, using MUI's `styled` API to replace the previous use of `ListSubheader` for rendering group headers in the autocomplete dropdown. This allows for more flexible and consistent styling.
* Updated the `renderGroup` prop in the `Autocomplete` component to use the new `GroupHeader` and `GroupItems` components, enhancing the appearance and structure of grouped course options.

**Code simplification:**

* Removed unnecessary imports (`FormHelperText`, `ListSubheader`) and related code, streamlining the component and reducing dependencies. [[1]](diffhunk://#diff-5f645ee121a8a54635b25ac04a631a5c46213bd3f37dbc05aaf4cf36b4423519L7-R19) [[2]](diffhunk://#diff-5f645ee121a8a54635b25ac04a631a5c46213bd3f37dbc05aaf4cf36b4423519L32-L59)
* Adjusted the order and logic of props in the `Autocomplete` component for clarity, including moving `options`, `groupBy`, and `getOptionLabel` to the top and removing redundant JSX fragments in `renderInput`.

### Demo 

https://github.com/user-attachments/assets/9ecd5e76-dd6f-4a35-8392-7a6c5c24cce8

