### PR TITLE
feat: implement changelog visibility logic in GeneratorPage

### DIFF
--- a/src/GeneratorPage.jsx
+++ b/src/GeneratorPage.jsx
@@ -38,10 +38,18 @@ function GeneratorPage() {
   const [timetables, setTimetables] = useState([]);
   const [selectedDuration, setSelectedDuration] = useState("");
   const [durations, setDurations] = useState([]);
-  const [isChangelogOpen, setIsChangelogOpen] = useState(true);
+  const [isChangelogOpen, setIsChangelogOpen] = useState(false);
   const [sortOption, setSortOption] = useState("");
   const [addedCourses, setAddedCourses] = useState([]);
   const isBelowMedium = useIsBelowMedium();
+
+  // Check if user has seen the changelog on mount
+  useEffect(() => {
+    const hasSeenChangelog = localStorage.getItem("hasSeenChangelog");
+    if (!hasSeenChangelog) {
+      setIsChangelogOpen(true);
+    }
+  }, []);
 
   // Clear all state when component unmounts
   useEffect(() => {
@@ -62,6 +70,7 @@ function GeneratorPage() {
 
   const handleCloseChangelog = () => {
     setIsChangelogOpen(false);
+    localStorage.setItem("hasSeenChangelog", "true");
   };
 
   const removeCourse = (course) => {


### PR DESCRIPTION
This pull request updates the behavior of the changelog modal in the `GeneratorPage` component to improve the user experience. The changelog will now only open automatically for users who have not seen it before, and this preference is remembered using local storage.

### Changelog modal experience improvements:

* The default state for `isChangelogOpen` is now `false`, and the component checks local storage on mount to determine if the changelog should be shown. If the user hasn't seen the changelog before, it will open automatically.
* When the changelog is closed, a flag is set in local storage to remember that the user has seen it, preventing it from opening automatically in the future.

### Testing
You can test by running the following in the console, then reloading the page.
```js
localStorage.removeItem('hasSeenChangelog')
```