### PR TITLE
feat: prevent light mode flash on load when user's preferred theme is dark

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
     <title>Brock Visual TimeTable</title>
+    <script>
+      // Set theme before React loads to prevent flash
+      (function () {
+        const prefersDark = window.matchMedia(
+          "(prefers-color-scheme: dark)",
+        ).matches;
+        const theme = prefersDark ? "dark" : "light";
+        const bgColor = prefersDark ? "#242526" : "#ffffff";
+
+        // Set background color immediately
+        document.documentElement.style.backgroundColor = bgColor;
+        document.documentElement.classList.add(theme + "-mode");
+
+        // Set body styles when available
+        if (document.body) {
+          document.body.style.backgroundColor = bgColor;
+          document.body.classList.add(theme + "-mode");
+        } else {
+          document.addEventListener("DOMContentLoaded", function () {
+            document.body.style.backgroundColor = bgColor;
+            document.body.classList.add(theme + "-mode");
+          });
+        }
+      })();
+    </script>
   </head>
 
   <body>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -102,9 +102,21 @@ const App = () => {
       "--theme-outline-color",
       theme.palette.outline,
     );
+    // Update background colors when theme changes
+    document.documentElement.style.backgroundColor =
+      theme.palette.background.default;
+    document.body.style.backgroundColor = theme.palette.background.default;
+    // Update theme classes
     document.body.classList.toggle("light-mode", mode === "light");
     document.body.classList.toggle("dark-mode", mode === "dark");
-  }, [theme.palette.divider, theme.palette.outline, mode]);
+    document.documentElement.classList.toggle("light-mode", mode === "light");
+    document.documentElement.classList.toggle("dark-mode", mode === "dark");
+  }, [
+    theme.palette.divider,
+    theme.palette.outline,
+    theme.palette.background.default,
+    mode,
+  ]);
 
   return (
     <Router>


### PR DESCRIPTION
This pull request improves the handling of light and dark themes to ensure the correct background color and theme classes are applied as early as possible, minimizing unwanted flashes of the wrong theme when the app loads or when the theme changes.

Theme initialization and update improvements:

* Added an inline script to `index.html` that sets the background color and theme class on both `document.documentElement` and `document.body` before React loads, based on the user's system preference. This helps prevent a flash of the incorrect theme on initial load.
* Updated the theme effect in `src/main.jsx` to also update the background color and theme classes on `document.documentElement` whenever the theme changes, ensuring consistency across the app.