### PR TITLE
feat: clear course input when add course button is pressed

### DIFF
--- a/src/GeneratorPage/components/Forms/InputFormTopComponent.jsx
+++ b/src/GeneratorPage/components/Forms/InputFormTopComponent.jsx
@@ -62,7 +62,8 @@ export default function InputFormTop({
   const addCourse = async () => {
     if (!validateInputs()) return;
 
-    const { cleanCourseCode, duration } = parseCourseCode(courseCode);
+    const originalCourseCode = courseCode;
+    const { cleanCourseCode, duration } = parseCourseCode(originalCourseCode);
 
     if (isCourseAlreadyAdded(cleanCourseCode)) {
       enqueueSnackbar(<MultiLineSnackbar message="Course already added" />, {
@@ -84,8 +85,15 @@ export default function InputFormTop({
     requestBlock = true;
     try {
       const courseData = await getCourse(cleanCourseCode, timetableType, term);
-      handleCourseData(courseData, cleanCourseCode, duration);
-      setCourseInputValue(""); // Clear the input value
+      handleCourseData(
+        courseData,
+        cleanCourseCode,
+        duration,
+        originalCourseCode,
+      );
+      // Clear the input and remount the autocomplete to ensure it resets
+      setCourseInputValue("");
+      setCourseCode("");
     } catch (error) {
       enqueueSnackbar(
         <MultiLineSnackbar message="Error fetching course data." />,
@@ -145,9 +153,14 @@ export default function InputFormTop({
     );
   };
 
-  const handleCourseData = (courseData, cleanCourseCode, duration) => {
+  const handleCourseData = (
+    courseData,
+    cleanCourseCode,
+    duration,
+    courseCodeLabel,
+  ) => {
     storeCourseData(courseData);
-    setAddedCourses([...addedCourses, courseCode]);
+    setAddedCourses([...addedCourses, courseCodeLabel]);
     addPinnedComponent(`${cleanCourseCode} DURATION ${duration}`);
     generateTimetables(sortChoice);
     setTimetables(getValidTimetables());


### PR DESCRIPTION
This pull request updates the course addition workflow in the `InputFormTopComponent.jsx` to improve the handling and display of course codes, and to ensure input fields are properly reset after adding a course. The main changes focus on consistently using the original course code input, updating state management, and improving the user experience when adding courses.

### Course code handling and state management:

* The `addCourse` function now explicitly saves the original course code input as `originalCourseCode` and passes it through the workflow to ensure the displayed course code matches the user's input.
* The `handleCourseData` function signature is updated to accept the original course code label, and the `addedCourses` state is now updated with this label instead of the cleaned course code, preserving the user's input format.

**Input reset improvements:**

* After successfully adding a course, both the input value and the internal course code state are cleared, ensuring the input field and autocomplete component are fully reset for the next entry.