### PR TITLE
fix: reset stale duration tracking variables when no courses are present

### DIFF
--- a/src/GeneratorPage/components/Calendar/CalendarComponent.jsx
+++ b/src/GeneratorPage/components/Calendar/CalendarComponent.jsx
@@ -182,6 +182,8 @@ export default function CalendarComponent({
       setNoTimetablesGenerated(false);
     } else {
       setNoCourses(true);
+      previousDuration = null;
+      aprioriDurationTimetable = null;
       const newEvents = createCalendarEvents(
         null,
         getDaysOfWeek,


### PR DESCRIPTION
This pull request makes a small update to the `CalendarComponent` to ensure that certain state variables are reset when no courses are present. This helps prevent stale data from affecting the calendar display. 

- Reset the `previousDuration` and `aprioriDurationTimetable` variables to `null` when no courses are detected, preventing potential carry-over of outdated values.