### PR TITLE
refactor: replace export options mui components with shadcn components, lessen padding/whitespace

### DIFF
--- a/src/components/generator/Forms/Settings/ExportOptions.jsx
+++ b/src/components/generator/Forms/Settings/ExportOptions.jsx
@@ -24,7 +24,7 @@ export default function ExportOptions() {
         <div>
           <Separator className="mb-2" />
           <Collapsible open={showHelp} onOpenChange={setShowHelp}>
-            <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md px-2 pt-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
+            <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
               <Info className="h-4 w-4" />
               <span className="flex-1 text-left">How to use the .ics file</span>
               {showHelp ? (


### PR DESCRIPTION
This pull request refactors the `ExportOptions` component to modernize its UI and reduce dependency on Material UI, switching to custom and third-party UI components for a more consistent design. The help section for using the `.ics` file is now implemented using a new collapsible pattern and updated icons, with improved styling and structure.

### UI framework migration and modernization:

* Replaced Material UI components (`Box`, `ListItemButton`, `Collapse`, `Typography`, etc.) with custom and third-party components such as `Collapsible`, `Separator`, and Lucide icons for a more streamlined and consistent UI.
* Updated the help section to use a new collapsible pattern (`Collapsible`, `CollapsibleTrigger`, `CollapsibleContent`) with improved styling, replacing the previous Material UI-based implementation.

### Styling and structure improvements:

* Refactored layout and spacing to use Tailwind CSS utility classes (e.g., `flex`, `gap-2`, `justify-center`) instead of Material UI's `sx` prop.
* Enhanced the help instructions for importing `.ics` files with clearer formatting and a more readable ordered list.

|Before|After|
|-|-|
|<img width="429" height="230" alt="image" src="https://github.com/user-attachments/assets/5ee149b7-eeec-483c-b3ad-3cada9af17dd" />|<img width="429" height="230" alt="image" src="https://github.com/user-attachments/assets/bb312577-c2dc-485f-ac14-b2cb5b25ba0c" />|
|<img width="429" height="747" alt="image" src="https://github.com/user-attachments/assets/e0cea763-11ce-4965-b2bb-00d7a5214a48" />|<img width="429" height="502" alt="image" src="https://github.com/user-attachments/assets/0a885464-422c-4a23-b75b-55b66120f7ce" />|