### PR TITLE
fix: open guide in new tab

### DIFF
--- a/src/components/sitewide/NavbarComponent.jsx
+++ b/src/components/sitewide/NavbarComponent.jsx
@@ -38,6 +38,7 @@ const NavbarComponent = () => {
       label: "Guide",
       to: "/guide",
       icon: BookOpen,
+      newTab: true,
     },
   ];
 
@@ -60,10 +61,17 @@ const NavbarComponent = () => {
               asChild
               onClick={() => setDrawerOpen(false)}
             >
-              <Link to={item.to}>
-                <Icon className="mr-2 h-4 w-4" />
-                {item.label}
-              </Link>
+              {item.newTab ? (
+                <a href={item.to} target="_blank" rel="noopener noreferrer">
+                  <Icon className="mr-2 h-4 w-4" />
+                  {item.label}
+                </a>
+              ) : (
+                <Link to={item.to}>
+                  <Icon className="mr-2 h-4 w-4" />
+                  {item.label}
+                </Link>
+              )}
             </Button>
           );
         })}
@@ -138,7 +146,13 @@ const NavbarComponent = () => {
           <div className="flex items-center gap-2">
             {navItems.map((item) => (
               <Button key={item.label} variant="ghost" asChild>
-                <Link to={item.to}>{item.label}</Link>
+                {item.newTab ? (
+                  <a href={item.to} target="_blank" rel="noopener noreferrer">
+                    {item.label}
+                  </a>
+                ) : (
+                  <Link to={item.to}>{item.label}</Link>
+                )}
               </Button>
             ))}
             <Button


### PR DESCRIPTION
Closes https://github.com/BrockTimetable/BrockVisualTimetable/issues/43

This pull request updates the `NavbarComponent` to support opening certain navigation links in a new browser tab.

### Navigation link behavior improvements:

* Added a `newTab` property to the "Guide" navigation item, indicating it should open in a new tab.
* Updated the rendering logic in the mobile drawer to use an `<a>` tag with `target="_blank"` and `rel="noopener noreferrer"` for navigation items with `newTab`, falling back to `<Link>` for others.
* Applied the same conditional rendering logic to the desktop navigation bar, ensuring consistency across devices for links that should open in a new tab.