### PR TITLE
chore: clean up analytics logging

### DIFF
--- a/src/components/generator/Forms/InputFormTopComponent.jsx
+++ b/src/components/generator/Forms/InputFormTopComponent.jsx
@@ -17,6 +17,8 @@ import { addPinnedComponent } from "@/lib/generator/pinnedComponents";
 import CourseOptions from "./Settings/CourseOptions";
 import SortOptions from "./Settings/SortOptions";
 
+const isAnalyticsEnabled = import.meta.env.PROD;
+
 export default function InputFormTop({
   setTimetables,
   setSelectedDuration,
@@ -171,11 +173,13 @@ export default function InputFormTop({
       updateDurations(durationLabel);
     }
 
-    ReactGA.event({
-      category: "Generator Event",
-      action: "Added Course",
-      label: `${cleanCourseCode} D${duration}`,
-    });
+    if (isAnalyticsEnabled) {
+      ReactGA.event({
+        category: "Generator Event",
+        action: "Added Course",
+        label: `${cleanCourseCode} D${duration}`,
+      });
+    }
   };
 
   const getDurationDates = (courseData, duration) => {

--- a/src/lib/generator/ExportCal.js
+++ b/src/lib/generator/ExportCal.js
@@ -1,5 +1,14 @@
+import ReactGA from "react-ga4";
+
+const isAnalyticsEnabled = import.meta.env.PROD;
 let cachedTimetableData;
 export function exportCal() {
+  if (isAnalyticsEnabled) {
+    ReactGA.event({
+      category: "Generator Event",
+      action: "Export Timetable",
+    });
+  }
   const blob = new Blob([generateICSFileData()], { type: "text/calendar" });
   const url = URL.createObjectURL(blob);
 

--- a/src/lib/generator/timetableGeneration/utils/UIEventsUtils.js
+++ b/src/lib/generator/timetableGeneration/utils/UIEventsUtils.js
@@ -1,6 +1,8 @@
 import eventBus from "@/lib/eventBus";
 import ReactGA from "react-ga4";
 
+const isAnalyticsEnabled = import.meta.env.PROD;
+
 export const emitNoValidTimetablesFound = () => {
   eventBus.emit("snackbar", {
     message:
@@ -47,10 +49,12 @@ export const emitTruncationWarning = () => {
       "The generated schedule results are truncated! Click the yellow '!' icon for more information!",
     variant: "warning",
   });
-  ReactGA.event({
-    category: "Generator Event",
-    action: "Truncation",
-  });
+  if (isAnalyticsEnabled) {
+    ReactGA.event({
+      category: "Generator Event",
+      action: "Truncation",
+    });
+  }
 };
 
 export const clearTruncationFlag = () => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,7 +11,10 @@ import ReactGA from "react-ga4";
 import "@/styles/index.css";
 
 const App = () => {
-  ReactGA.initialize("G-M2NP1M6YSK");
+  useEffect(() => {
+    if (!import.meta.env.PROD) return;
+    ReactGA.initialize("G-M2NP1M6YSK");
+  }, []);
   const [mode, setMode] = useState(() => {
     const prefersDark = window.matchMedia(
       "(prefers-color-scheme: dark)",

--- a/src/pages/GeneratorPage.jsx
+++ b/src/pages/GeneratorPage.jsx
@@ -31,11 +31,14 @@ import {
 import FooterComponent from "@/components/sitewide/FooterComponent";
 
 function GeneratorPage() {
-  ReactGA.send({
-    hitType: "pageview",
-    page: "Generator",
-    title: "Brock Visual TimeTable",
-  });
+  useEffect(() => {
+    if (!import.meta.env.PROD) return;
+    ReactGA.send({
+      hitType: "pageview",
+      page: "Generator",
+      title: "Brock Visual TimeTable",
+    });
+  }, []);
   const [timetables, setTimetables] = useState([]);
   const [selectedDuration, setSelectedDuration] = useState("");
   const [durations, setDurations] = useState([]);

--- a/src/pages/GuidePage.jsx
+++ b/src/pages/GuidePage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { NavbarComponent } from "@/components/guide";
 import CssBaseline from "@mui/material/CssBaseline";
 import Grid from "@mui/material/Grid";
@@ -19,11 +19,14 @@ import Divider from "@mui/material/Divider";
 import FooterComponent from "@/components/sitewide/FooterComponent";
 
 function GuidePage() {
-  ReactGA.send({
-    hitType: "pageview",
-    page: "Guide",
-    title: "Brock Visual Guide",
-  });
+  useEffect(() => {
+    if (!import.meta.env.PROD) return;
+    ReactGA.send({
+      hitType: "pageview",
+      page: "Guide",
+      title: "Brock Visual Guide",
+    });
+  }, []);
   const isBelowMedium = useIsBelowMedium();
   const theme = useTheme();
   const [openCourseCode, setOpenCourseCode] = useState(false);


### PR DESCRIPTION
This pull request adds Google Analytics event tracking throughout the application, but ensures that analytics are only enabled in production builds. The changes include initializing Google Analytics conditionally, sending pageview events on key pages, and tracking specific user actions (such as exporting timetables, adding courses, and handling truncation warnings). All analytics logic is gated behind a production environment check to avoid polluting analytics data during development.

**Analytics Integration (Production Only):**
- Added a production environment check (`isAnalyticsEnabled`) to all components and utilities that interact with Google Analytics, ensuring events are only sent in production. 
- Initialized Google Analytics only when running in production, preventing unnecessary initialization during development.

**Event Tracking for User Actions:**
- Added Google Analytics event tracking for exporting timetables, adding courses, and truncation warnings, all gated by the production check. 

**Pageview Tracking:**
- Sent pageview events to Google Analytics on the main Generator and Guide pages, but only in production. 

**Minor Refactoring:**
- Updated imports in `GuidePage.jsx` to include `useEffect` for analytics tracking.