### PR TITLE
fix: defer calendar navigation render warning

### DIFF
--- a/src/components/generator/Calendar/CalendarComponent.jsx
+++ b/src/components/generator/Calendar/CalendarComponent.jsx
@@ -201,12 +201,18 @@ export default function CalendarComponent({
   ]);
 
   const handleCalendarViewClick = (durationLabel) => {
-    const calendarApi = calendarRef.current.getApi();
+    const calendarApi = calendarRef.current?.getApi();
+    if (!calendarApi) return;
+
     const [startUnix, endUnix, duration] = durationLabel.split("-");
 
     const startDate = new Date(parseInt(startUnix) * 1000);
     const navigationDate = calculateNavigationDate(startDate);
-    calendarApi.gotoDate(navigationDate);
+
+    // Defer gotoDate to avoid flushSync warning during React render
+    queueMicrotask(() => {
+      calendarApi.gotoDate(navigationDate);
+    });
 
     if (previousDuration == null) {
       previousDuration = duration;
@@ -424,7 +430,10 @@ export default function CalendarComponent({
       if (calendarRef.current && calendarRef.current.getApi) {
         try {
           const calendarApi = calendarRef.current.getApi();
-          calendarApi.gotoDate(date);
+          // Defer gotoDate to avoid flushSync warning during React render
+          queueMicrotask(() => {
+            calendarApi.gotoDate(date);
+          });
         } catch (error) {
           // Error handling silently ignored
         }

--- a/src/components/generator/Calendar/hooks/useTimetableManagement.jsx
+++ b/src/components/generator/Calendar/hooks/useTimetableManagement.jsx
@@ -65,7 +65,10 @@ export const useTimetableManagement = ({
         navigationDate.setDate(navigationDate.getDate() - daysToSubtract);
       }
 
-      calendarApi.gotoDate(navigationDate);
+      // Defer gotoDate to avoid flushSync warning during React render
+      queueMicrotask(() => {
+        calendarApi.gotoDate(navigationDate);
+      });
 
       if (previousDuration == null) {
         previousDuration = duration;


### PR DESCRIPTION
This pull request addresses a React warning related to calling `gotoDate` on the calendar API during the render phase. The main improvement is deferring these calls using `queueMicrotask` to ensure they occur outside of React's synchronous rendering, preventing potential issues and warnings.

**Improvements to calendar navigation logic:**

* Updated all instances where `calendarApi.gotoDate` is called to defer execution using `queueMicrotask`, avoiding flushSync warnings during React render. 
* Added null checks for `calendarRef.current` and its API to prevent runtime errors when the reference is not available. (`src/components/generator/Calendar/CalendarComponent.jsx`)