### PR TITLE
[codex] Add aggregated GA analytics events

### DIFF
--- a/src/components/generator/Export/ExportCalendarButton.jsx
+++ b/src/components/generator/Export/ExportCalendarButton.jsx
@@ -65,7 +65,7 @@ export default function ExportCalendarButton({ timetables, durations }) {
       return;
     }
 
-    exportCal();
+    exportCal({ durationCount: durations.length });
   };
 
   return (
@@ -105,7 +105,7 @@ export default function ExportCalendarButton({ timetables, durations }) {
             <Button
               onClick={() => {
                 setConfirmOpen(false);
-                exportCal();
+                exportCal({ durationCount: durations.length });
               }}
             >
               Export anyway

--- a/src/components/generator/Forms/InputFormTopComponent.jsx
+++ b/src/components/generator/Forms/InputFormTopComponent.jsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef } from "react";
 import { useSnackbar } from "notistack";
-import ReactGA from "react-ga4";
 
 import MultiLineSnackbar from "@/components/sitewide/MultiLineSnackbar";
 
-import { storeCourseData, removeCourseData } from "@/lib/generator/courseData";
+import { storeCourseData } from "@/lib/generator/courseData";
+import { trackCourseAddResult, trackScheduleGenerated } from "@/lib/analytics";
 import { getCourse, getNameList } from "@/lib/generator/fetchData";
 import {
   generateTimetables,
@@ -14,8 +14,6 @@ import { addPinnedComponent } from "@/lib/generator/pinnedComponents";
 
 import CourseOptions from "./Settings/CourseOptions";
 import SortOptions from "./Settings/SortOptions";
-
-const isAnalyticsEnabled = import.meta.env.PROD;
 
 export default function InputFormTop({
   setTimetables,
@@ -64,11 +62,28 @@ export default function InputFormTop({
     const upperCode = ((overrideValue ?? courseValue) || "")
       .trim()
       .toUpperCase();
-    if (!validateInputs(upperCode)) return;
+    const validationFailureReason = getValidationFailureReason(upperCode);
+    if (validationFailureReason) {
+      trackCourseAddFailure({
+        failureReason: validationFailureReason,
+        courseCount: addedCourses.length,
+      });
+      showValidationMessage(validationFailureReason);
+      return;
+    }
 
     const { cleanCourseCode, duration } = parseCourseCode(upperCode);
+    const courseMetadata = getCourseAnalyticsMetadata(
+      cleanCourseCode,
+      duration,
+    );
 
     if (isCourseAlreadyAdded(cleanCourseCode)) {
+      trackCourseAddFailure({
+        failureReason: "duplicate_course",
+        courseCount: addedCourses.length,
+        ...courseMetadata,
+      });
       enqueueSnackbar(<MultiLineSnackbar message="Course already added" />, {
         variant: "info",
       });
@@ -88,10 +103,21 @@ export default function InputFormTop({
     requestBlock.current = true;
     try {
       const courseData = await getCourse(cleanCourseCode, timetableType, term);
-      handleCourseData(courseData, cleanCourseCode, duration, upperCode);
+      handleCourseData(
+        courseData,
+        cleanCourseCode,
+        duration,
+        upperCode,
+        courseMetadata,
+      );
       // Clear input after a successful add
       setCourseValue("");
     } catch (error) {
+      trackCourseAddFailure({
+        failureReason: "fetch_error",
+        courseCount: addedCourses.length,
+        ...courseMetadata,
+      });
       enqueueSnackbar(
         <MultiLineSnackbar message="Error fetching course data." />,
         { variant: "error" },
@@ -101,33 +127,46 @@ export default function InputFormTop({
     }
   };
 
-  const validateInputs = (code) => {
+  const getValidationFailureReason = (code) => {
     if (!timetableType || timetableType === "NOVALUE") {
+      return "missing_timetable";
+    }
+
+    if (!term || term === "NOVALUE") {
+      return "missing_term";
+    }
+
+    if (!isValidCourseCode(code)) {
+      return "invalid_course_code";
+    }
+
+    return null;
+  };
+
+  const showValidationMessage = (failureReason) => {
+    if (failureReason === "missing_timetable") {
       enqueueSnackbar(
         <MultiLineSnackbar message="Please select a timetable." />,
         { variant: "warning" },
       );
-      return false;
+      return;
     }
 
-    if (!term || term === "NOVALUE") {
+    if (failureReason === "missing_term") {
       enqueueSnackbar(<MultiLineSnackbar message="Please select a term." />, {
         variant: "warning",
       });
-      return false;
+      return;
     }
 
-    if (!isValidCourseCode(code)) {
+    if (failureReason === "invalid_course_code") {
       enqueueSnackbar(
         <MultiLineSnackbar message='Invalid course code! Example: "COSC 1P02 D2"' />,
         {
           variant: "warning",
         },
       );
-      return false;
     }
-
-    return true;
   };
 
   const isValidCourseCode = (code) => {
@@ -140,6 +179,31 @@ export default function InputFormTop({
     const cleanCourseCode = split[0] + split[1];
     const duration = split[2].substring(1);
     return { cleanCourseCode, duration };
+  };
+
+  const getCourseAnalyticsMetadata = (cleanCourseCode, duration) => ({
+    subjectCode: cleanCourseCode.substring(0, 4),
+    courseLevel: cleanCourseCode.substring(4, 5),
+    duration: `D${duration}`,
+  });
+
+  const trackCourseAddFailure = ({
+    failureReason,
+    courseCount,
+    subjectCode,
+    courseLevel,
+    duration,
+  }) => {
+    trackCourseAddResult({
+      result: "failure",
+      failureReason,
+      subjectCode,
+      courseLevel,
+      duration,
+      term,
+      timetableType,
+      courseCount,
+    });
   };
 
   const isCourseAlreadyAdded = (cleanCourseCode) => {
@@ -155,12 +219,15 @@ export default function InputFormTop({
     cleanCourseCode,
     duration,
     courseCodeLabel,
+    courseMetadata,
   ) => {
     storeCourseData(courseData);
+    const updatedCourseCount = addedCourses.length + 1;
     setAddedCourses([...addedCourses, courseCodeLabel]);
     addPinnedComponent(`${cleanCourseCode} DURATION ${duration}`);
     generateTimetables(sortChoice);
-    setTimetables(getValidTimetables());
+    const validTimetables = getValidTimetables();
+    setTimetables(validTimetables);
 
     const { durationStartDate, durationEndDate } = getDurationDates(
       courseData,
@@ -171,13 +238,20 @@ export default function InputFormTop({
       updateDurations(durationLabel);
     }
 
-    if (isAnalyticsEnabled) {
-      ReactGA.event({
-        category: "Generator Event",
-        action: "Added Course",
-        label: `${cleanCourseCode} D${duration}`,
-      });
-    }
+    trackCourseAddResult({
+      result: "success",
+      ...courseMetadata,
+      term,
+      timetableType,
+      courseCount: updatedCourseCount,
+    });
+    trackScheduleGenerated({
+      trigger: "course_added",
+      courseCount: updatedCourseCount,
+      resultCount: validTimetables.length,
+      sortOption: sortChoice,
+      hasResults: validTimetables.length > 0,
+    });
   };
 
   const getDurationDates = (courseData, duration) => {

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,117 @@
+import ReactGA from "react-ga4";
+
+const GA_MEASUREMENT_ID = "G-M2NP1M6YSK";
+const isAnalyticsEnabled = import.meta.env.PROD;
+
+let initialized = false;
+
+const cleanParams = (params) =>
+  Object.fromEntries(
+    Object.entries(params).filter(
+      ([, value]) => value !== undefined && value !== null && value !== "",
+    ),
+  );
+
+export const initializeAnalytics = () => {
+  if (!isAnalyticsEnabled || initialized) return;
+
+  ReactGA.initialize(GA_MEASUREMENT_ID);
+  initialized = true;
+};
+
+export const trackPageView = ({ page, title }) => {
+  if (!isAnalyticsEnabled) return;
+
+  initializeAnalytics();
+  ReactGA.event(
+    "page_view",
+    cleanParams({
+      page_name: page,
+      page_title: title,
+      page_path:
+        typeof window === "undefined" ? undefined : window.location.pathname,
+      page_location:
+        typeof window === "undefined" ? undefined : window.location.href,
+    }),
+  );
+};
+
+export const trackCourseAddResult = ({
+  result,
+  failureReason,
+  subjectCode,
+  courseLevel,
+  duration,
+  term,
+  timetableType,
+  courseCount,
+}) => {
+  if (!isAnalyticsEnabled) return;
+
+  initializeAnalytics();
+  ReactGA.event(
+    "course_add_result",
+    cleanParams({
+      result,
+      failure_reason: failureReason,
+      subject_code: subjectCode,
+      course_level: courseLevel,
+      duration,
+      term,
+      timetable_type: timetableType,
+      course_count: courseCount,
+    }),
+  );
+};
+
+export const trackScheduleGenerated = ({
+  trigger,
+  courseCount,
+  resultCount,
+  sortOption,
+  hasResults,
+  isTruncated,
+}) => {
+  if (!isAnalyticsEnabled) return;
+
+  initializeAnalytics();
+  ReactGA.event(
+    "schedule_generated",
+    cleanParams({
+      trigger,
+      course_count: courseCount,
+      result_count: resultCount,
+      sort_option: sortOption,
+      has_results: hasResults,
+      is_truncated: isTruncated,
+    }),
+  );
+};
+
+export const trackCalendarExportCompleted = ({
+  courseCount,
+  durationCount,
+}) => {
+  if (!isAnalyticsEnabled) return;
+
+  initializeAnalytics();
+  ReactGA.event(
+    "calendar_export_completed",
+    cleanParams({
+      course_count: courseCount,
+      duration_count: durationCount,
+      export_path: "ics_download",
+    }),
+  );
+};
+
+export const trackTruncationWarning = () => {
+  if (!isAnalyticsEnabled) return;
+
+  initializeAnalytics();
+  ReactGA.event("schedule_generated", {
+    trigger: "truncation_warning",
+    is_truncated: true,
+    has_results: true,
+  });
+};

--- a/src/lib/generator/ExportCal.js
+++ b/src/lib/generator/ExportCal.js
@@ -1,15 +1,8 @@
-import ReactGA from "react-ga4";
+import { trackCalendarExportCompleted } from "@/lib/analytics";
 
-const isAnalyticsEnabled = import.meta.env.PROD;
 const ICS_TIMEZONE = "America/Toronto";
 let cachedTimetableData;
-export function exportCal() {
-  if (isAnalyticsEnabled) {
-    ReactGA.event({
-      category: "Generator Event",
-      action: "Export Timetable",
-    });
-  }
+export function exportCal({ durationCount } = {}) {
   const blob = new Blob([generateICSFileData()], { type: "text/calendar" });
   const url = URL.createObjectURL(blob);
 
@@ -22,6 +15,11 @@ export function exportCal() {
 
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+
+  trackCalendarExportCompleted({
+    courseCount: cachedTimetableData?.courses?.length,
+    durationCount,
+  });
 }
 
 function generateICSFileData() {

--- a/src/lib/generator/timetableGeneration/utils/UIEventsUtils.js
+++ b/src/lib/generator/timetableGeneration/utils/UIEventsUtils.js
@@ -1,7 +1,5 @@
 import eventBus from "@/lib/eventBus";
-import ReactGA from "react-ga4";
-
-const isAnalyticsEnabled = import.meta.env.PROD;
+import { trackTruncationWarning } from "@/lib/analytics";
 
 export const emitNoValidTimetablesFound = () => {
   eventBus.emit("snackbar", {
@@ -49,12 +47,7 @@ export const emitTruncationWarning = () => {
       "The generated schedule results are truncated! Click the yellow '!' icon for more information!",
     variant: "warning",
   });
-  if (isAnalyticsEnabled) {
-    ReactGA.event({
-      category: "Generator Event",
-      action: "Truncation",
-    });
-  }
+  trackTruncationWarning();
 };
 
 export const clearTruncationFlag = () => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,15 +5,14 @@ import GeneratorPage from "@/pages/GeneratorPage";
 import GuidePage from "@/pages/GuidePage";
 import ColorModeContext from "@/lib/contexts/sitewide/ColorModeContext";
 import CustomSnackbarProvider from "@/components/sitewide/SnackbarProvider";
-import ReactGA from "react-ga4";
+import { initializeAnalytics } from "@/lib/analytics";
 import "@/styles/index.css";
 
 const THEME_STORAGE_KEY = "bt-theme-mode";
 
 const App = () => {
   useEffect(() => {
-    if (!import.meta.env.PROD) return;
-    ReactGA.initialize("G-M2NP1M6YSK");
+    initializeAnalytics();
   }, []);
   const [mode, setMode] = useState(() => {
     if (typeof window === "undefined") {

--- a/src/pages/GeneratorPage.jsx
+++ b/src/pages/GeneratorPage.jsx
@@ -12,7 +12,7 @@ import {
   CourseColorsContext,
 } from "@/lib/contexts/generator/CourseColorsContext";
 import IntroGuideWidget from "@/components/generator/Dialogs/IntroGuideWidget";
-import ReactGA from "react-ga4";
+import { trackPageView } from "@/lib/analytics";
 import {
   generateTimetables,
   getValidTimetables,
@@ -23,9 +23,7 @@ import FooterComponent from "@/components/sitewide/FooterComponent";
 
 function GeneratorPage() {
   useEffect(() => {
-    if (!import.meta.env.PROD) return;
-    ReactGA.send({
-      hitType: "pageview",
+    trackPageView({
       page: "Generator",
       title: "Brock Visual TimeTable",
     });

--- a/src/pages/GuidePage.jsx
+++ b/src/pages/GuidePage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import ReactGA from "react-ga4";
+import { trackPageView } from "@/lib/analytics";
 import { NavbarComponent } from "@/components/guide";
 import FooterComponent from "@/components/sitewide/FooterComponent";
 import {
@@ -13,9 +13,7 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 
 function GuidePage() {
   useEffect(() => {
-    if (!import.meta.env.PROD) return;
-    ReactGA.send({
-      hitType: "pageview",
+    trackPageView({
       page: "Guide",
       title: "Brock Visual Guide",
     });


### PR DESCRIPTION
## Summary
- centralize frontend GA calls in a shared analytics helper
- replace exact course-code events with aggregated course add results
- track schedule generation, exports, truncation, and page views through the helper

## Validation
- npm test -- --run
- npm run build

Note: npm run lint still reports existing repo-wide lint issues unrelated to this change.
