### PR TITLE
Add unavoidable conflict handling

### DIFF
--- a/src/components/generator/Calendar/CalendarComponent.jsx
+++ b/src/components/generator/Calendar/CalendarComponent.jsx
@@ -67,6 +67,7 @@ export default function CalendarComponent({
     useContext(CourseColorsContext);
   const [isTruncated, setIsTruncated] = useState(false);
   const [noTimetablesGenerated, setNoTimetablesGenerated] = useState(false);
+  const [conflictPresent, setConflictPresent] = useState(false);
   const [, setNoCourses] = useState(true);
   const [timeslotsOverridden, setTimeslotsOverridden] = useState(false);
   const [showWeekends, setShowWeekends] = useState(false);
@@ -100,6 +101,7 @@ export default function CalendarComponent({
     setCurrentTimetableIndex,
     setIsTruncated,
     setTimeslotsOverridden,
+    setConflictPresent,
   });
 
   useEffect(() => {
@@ -523,6 +525,7 @@ export default function CalendarComponent({
             isTruncated={isTruncated}
             noTimetablesGenerated={noTimetablesGenerated}
             timeslotsOverridden={timeslotsOverridden}
+            conflictPresent={conflictPresent}
             handleFirst={handleFirst}
             handlePrevious={handlePrevious}
             handleNext={handleNext}

--- a/src/components/generator/Calendar/CalendarNavBar.jsx
+++ b/src/components/generator/Calendar/CalendarNavBar.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import {
+  AlertTriangle,
   ChevronLeft,
   ChevronRight,
   ChevronsLeft,
@@ -13,6 +14,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import eventBus from "@/lib/eventBus";
 import {
   Select,
   SelectContent,
@@ -37,6 +39,7 @@ export default function CalendarNavBar({
   isTruncated,
   noTimetablesGenerated,
   timeslotsOverridden,
+  conflictPresent,
   handleFirst,
   handlePrevious,
   handleNext,
@@ -117,6 +120,18 @@ export default function CalendarNavBar({
               </div>
             </PopoverContent>
           </Popover>
+        )}
+        {conflictPresent && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={`${infoButtonBaseClassName} text-red-600 hover:text-red-600`}
+            aria-label="View schedule conflict details"
+            onClick={() => eventBus.emit("openConflictDialog")}
+          >
+            <AlertTriangle className="h-4 w-4" />
+          </Button>
         )}
         {timeslotsOverridden && (
           <Popover>
@@ -227,6 +242,7 @@ CalendarNavBar.propTypes = {
   isTruncated: PropTypes.bool.isRequired,
   noTimetablesGenerated: PropTypes.bool.isRequired,
   timeslotsOverridden: PropTypes.bool.isRequired,
+  conflictPresent: PropTypes.bool.isRequired,
   handleFirst: PropTypes.func.isRequired,
   handlePrevious: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,

--- a/src/components/generator/Calendar/hooks/useEventBusHandlers.js
+++ b/src/components/generator/Calendar/hooks/useEventBusHandlers.js
@@ -5,6 +5,7 @@ export const useEventBusHandlers = ({
   setCurrentTimetableIndex,
   setIsTruncated,
   setTimeslotsOverridden,
+  setConflictPresent,
 }) => {
   useEffect(() => {
     eventBus.on("requestSetTimetableIndex", () => {
@@ -35,4 +36,14 @@ export const useEventBusHandlers = ({
       eventBus.off("overridden", handleTimeslotsOverridden);
     };
   }, [setTimeslotsOverridden]);
+
+  useEffect(() => {
+    const handleConflict = (info) => {
+      setConflictPresent(Boolean(info));
+    };
+    eventBus.on("conflict", handleConflict);
+    return () => {
+      eventBus.off("conflict", handleConflict);
+    };
+  }, [setConflictPresent]);
 };

--- a/src/components/generator/Calendar/utils/calendarConfigUtils.js
+++ b/src/components/generator/Calendar/utils/calendarConfigUtils.js
@@ -29,8 +29,13 @@ export const getFullCalendarConfig = ({
   allDaySlot: true,
   allDayText: "ONLINE",
   eventContent: (eventInfo) => renderEventContent(eventInfo, isMobile),
-  eventClassNames: (arg) =>
-    arg.event.extendedProps?.isPinned ? ["fc-event-pinned"] : [],
+  eventClassNames: (arg) => {
+    const classes = [];
+    if (arg.event.extendedProps?.isPinned) classes.push("fc-event-pinned");
+    if (arg.event.extendedProps?.isConflicting)
+      classes.push("fc-event-conflict");
+    return classes;
+  },
   eventDidMount: (arg) => {
     if (arg.event.extendedProps?.isPinned) {
       arg.el.style.borderColor = "transparent";

--- a/src/components/generator/Dialogs/ConflictDialog.jsx
+++ b/src/components/generator/Dialogs/ConflictDialog.jsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useCallback,
+} from "react";
 import { createPortal } from "react-dom";
 import PropTypes from "prop-types";
 import { AlertTriangle, Trash2 } from "lucide-react";
@@ -46,7 +52,14 @@ const computeConflictAnchor = () => {
     bottom = Math.max(bottom, rect.bottom);
   });
 
-  return { left, top, right, bottom, width: right - left, height: bottom - top };
+  return {
+    left,
+    top,
+    right,
+    bottom,
+    width: right - left,
+    height: bottom - top,
+  };
 };
 
 // Brings the conflict into view, then (when bottomReserved is set, e.g. the

--- a/src/components/generator/Dialogs/ConflictDialog.jsx
+++ b/src/components/generator/Dialogs/ConflictDialog.jsx
@@ -1,0 +1,344 @@
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
+import PropTypes from "prop-types";
+import { AlertTriangle, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useIsMobile } from "@/lib/utils/screenSizeUtils";
+
+// "COSC1P02" -> "COSC 1P02"
+const formatCourseCode = (code) =>
+  /^[A-Z]{4}\d/.test(code) ? `${code.slice(0, 4)} ${code.slice(4)}` : code;
+
+// "1100-1230" -> "11:00 - 12:30"
+const formatTime = (time) =>
+  time
+    .split("-")
+    .map((part) => {
+      const t = part.trim().padStart(4, "0");
+      return `${t.slice(0, 2)}:${t.slice(2, 4)}`;
+    })
+    .join(" - ");
+
+const formatComponent = (component) =>
+  `${formatCourseCode(component.courseCode)} ${component.type} (${component.days.join(
+    " ",
+  )} ${formatTime(component.time)})`;
+
+const CARD_WIDTH = 340;
+const GAP = 12;
+
+// Bounding box that encloses every highlighted conflict event in the calendar.
+const computeConflictAnchor = () => {
+  const els = Array.from(
+    document.querySelectorAll("#Calendar .fc-event-conflict"),
+  );
+  if (els.length === 0) return null;
+
+  let left = Infinity;
+  let top = Infinity;
+  let right = -Infinity;
+  let bottom = -Infinity;
+  els.forEach((el) => {
+    const rect = el.getBoundingClientRect();
+    left = Math.min(left, rect.left);
+    top = Math.min(top, rect.top);
+    right = Math.max(right, rect.right);
+    bottom = Math.max(bottom, rect.bottom);
+  });
+
+  return { left, top, right, bottom, width: right - left, height: bottom - top };
+};
+
+// Brings the conflict into view, then (when bottomReserved is set, e.g. the
+// mobile bottom sheet) nudges it into the visible area above the sheet so it is
+// not hidden behind it. Scrolls the calendar's inner scroller first, then the
+// page for any remainder, so the two never double-count.
+const scrollConflictIntoFrame = (el, bottomReserved) => {
+  el.scrollIntoView({ block: "center", inline: "nearest" });
+  if (bottomReserved <= 0) return;
+
+  const available = window.innerHeight - bottomReserved;
+  if (available <= 0) return;
+
+  const rect = el.getBoundingClientRect();
+  const currentCenter = rect.top + rect.height / 2;
+  let delta = currentCenter - available / 2;
+  if (Math.abs(delta) < 4) return;
+
+  const scroller = el.closest(".fc-scroller");
+  if (scroller) {
+    const before = scroller.scrollTop;
+    scroller.scrollTop += delta;
+    delta -= scroller.scrollTop - before;
+  }
+  if (Math.abs(delta) > 1) {
+    window.scrollBy(0, delta);
+  }
+};
+
+export default function ConflictDialog({
+  open,
+  onClose,
+  conflictInfo,
+  onRemoveCourse,
+}) {
+  const isMobile = useIsMobile();
+  const [anchor, setAnchor] = useState(null);
+  const cardRef = useRef(null);
+  const [cardStyle, setCardStyle] = useState({
+    left: 0,
+    top: 0,
+    visibility: "hidden",
+  });
+
+  const refreshAnchor = useCallback(() => {
+    setAnchor(computeConflictAnchor());
+  }, []);
+
+  // On open: scroll/frame the conflict into view, freeze page scrolling, then
+  // lock onto its position. The calendar may render its events a frame or two
+  // later, so retry briefly until the highlighted elements appear (falling back
+  // to a centered/sheet card). The anchor is recomputed on any scroll/resize so
+  // the highlight always stays aligned with the conflict.
+  useEffect(() => {
+    if (!open) return undefined;
+
+    let cancelled = false;
+    let rafId;
+    let timeoutId;
+    let scrollLocked = false;
+
+    const { body } = document;
+    const prevOverflow = body.style.overflow;
+    const prevPaddingRight = body.style.paddingRight;
+
+    const lockScroll = () => {
+      if (scrollLocked) return;
+      scrollLocked = true;
+      // Compensate for the removed scrollbar so nothing shifts horizontally.
+      const scrollbarWidth =
+        window.innerWidth - document.documentElement.clientWidth;
+      if (scrollbarWidth > 0) {
+        const currentPadding =
+          parseFloat(getComputedStyle(body).paddingRight) || 0;
+        body.style.paddingRight = `${currentPadding + scrollbarWidth}px`;
+      }
+      body.style.overflow = "hidden";
+    };
+
+    const frameAndLock = () => {
+      if (cancelled) return;
+      const el = document.querySelector("#Calendar .fc-event-conflict");
+      if (el) {
+        // On mobile reserve the bottom-sheet height so the conflict frames above
+        // it; on desktop the floating card is placed around the conflict later.
+        const reserved =
+          isMobile && cardRef.current ? cardRef.current.offsetHeight + GAP : 0;
+        scrollConflictIntoFrame(el, reserved);
+      }
+      lockScroll();
+      rafId = requestAnimationFrame(() => {
+        if (!cancelled) refreshAnchor();
+      });
+    };
+
+    const attempt = (remaining) => {
+      if (cancelled) return;
+      const els = document.querySelectorAll("#Calendar .fc-event-conflict");
+      if (els.length > 0) {
+        // Wait a frame so the card (sheet) is laid out and measurable.
+        rafId = requestAnimationFrame(frameAndLock);
+        return;
+      }
+      if (remaining > 0) {
+        timeoutId = setTimeout(() => attempt(remaining - 1), 100);
+      } else {
+        lockScroll();
+        setAnchor(null);
+      }
+    };
+
+    attempt(10);
+    window.addEventListener("resize", refreshAnchor);
+    // Capture phase so scrolling of any inner container repositions the anchor.
+    window.addEventListener("scroll", refreshAnchor, true);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+      clearTimeout(timeoutId);
+      window.removeEventListener("resize", refreshAnchor);
+      window.removeEventListener("scroll", refreshAnchor, true);
+      body.style.overflow = prevOverflow;
+      body.style.paddingRight = prevPaddingRight;
+    };
+  }, [open, conflictInfo, isMobile, refreshAnchor]);
+
+  // Desktop only: place the floating card beneath the conflict (or above it
+  // when there is no room). On mobile the card is a fixed bottom sheet.
+  useLayoutEffect(() => {
+    if (!open || isMobile) return;
+    const card = cardRef.current;
+    if (!card) return;
+
+    const { innerWidth: vw, innerHeight: vh } = window;
+    const cardHeight = card.offsetHeight;
+    const width = Math.min(CARD_WIDTH, vw - 2 * GAP);
+
+    let left;
+    let top;
+    if (anchor) {
+      const centerX = anchor.left + anchor.width / 2;
+      left = centerX - width / 2;
+      const spaceBelow = vh - anchor.bottom;
+      top =
+        spaceBelow >= cardHeight + GAP
+          ? anchor.bottom + GAP
+          : anchor.top - cardHeight - GAP;
+    } else {
+      // Fallback: no conflict element on screen — center the card.
+      left = (vw - width) / 2;
+      top = (vh - cardHeight) / 2;
+    }
+
+    left = Math.max(GAP, Math.min(left, vw - width - GAP));
+    top = Math.max(GAP, Math.min(top, vh - cardHeight - GAP));
+
+    setCardStyle({ left, top, width, visibility: "visible" });
+  }, [open, isMobile, anchor, conflictInfo]);
+
+  if (!open || !conflictInfo) return null;
+
+  const { involvedCourses = [], pairs = [] } = conflictInfo;
+
+  const cardBody = (
+    <>
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 text-base font-semibold">
+          <AlertTriangle className="h-5 w-5 shrink-0 text-red-600" />
+          Unavoidable Schedule Conflict
+        </div>
+        <p className="text-sm text-muted-foreground">
+          These class components can&apos;t fit together without overlapping.
+          Remove/unpin one of them, or keep this timetable and ignore the
+          overlap.
+        </p>
+      </div>
+
+      <div className="rounded-md border border-red-200 bg-red-50 p-2.5 dark:border-red-900/50 dark:bg-red-950/30">
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          {pairs.map((pair, index) => (
+            <li key={index} className="leading-snug">
+              <div className="font-medium text-foreground">
+                {formatComponent(pair.a)}
+              </div>
+              <div className="text-xs uppercase tracking-wide text-red-600 dark:text-red-400">
+                overlaps
+              </div>
+              <div className="font-medium text-foreground">
+                {formatComponent(pair.b)}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="text-sm font-medium text-foreground">
+          Remove a course
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {involvedCourses.map((course) => (
+            <Button
+              key={course.courseCode}
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => onRemoveCourse(course.courseCode)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              {formatCourseCode(course.courseCode)}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-end pt-1">
+        <Button size="sm" onClick={onClose}>
+          Pin &amp; Ignore
+        </Button>
+      </div>
+    </>
+  );
+
+  return createPortal(
+    <div className="fixed inset-0 z-[1000]">
+      {/* Spotlight: darkens everything except the conflict cut-out. */}
+      {anchor ? (
+        <div
+          className="pointer-events-none fixed rounded-md"
+          style={{
+            left: anchor.left - 4,
+            top: anchor.top - 4,
+            width: anchor.width + 8,
+            height: anchor.height + 8,
+            boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.7)",
+            border: "2px solid #dc2626",
+          }}
+        />
+      ) : (
+        <div className="fixed inset-0 bg-black/70" />
+      )}
+
+      {/* Blocks interaction with the page behind. Clicking the darkened area
+          intentionally does nothing so conflicts can't be pinned by accident —
+          the user must use the buttons in the card. */}
+      <div className="fixed inset-0" aria-hidden="true" />
+
+      {isMobile ? (
+        <div
+          ref={cardRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Schedule conflict"
+          className="fixed inset-x-0 bottom-0 z-[1001] max-h-[60vh] space-y-3 overflow-y-auto rounded-t-2xl border bg-background p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] shadow-xl"
+        >
+          <div className="mx-auto -mt-1 mb-1 h-1 w-10 rounded-full bg-muted-foreground/30" />
+          {cardBody}
+        </div>
+      ) : (
+        <div
+          ref={cardRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Schedule conflict"
+          className="fixed z-[1001] space-y-3 rounded-lg border bg-background p-4 shadow-xl"
+          style={cardStyle}
+        >
+          {cardBody}
+        </div>
+      )}
+    </div>,
+    document.body,
+  );
+}
+
+ConflictDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onRemoveCourse: PropTypes.func.isRequired,
+  conflictInfo: PropTypes.shape({
+    involvedCourses: PropTypes.arrayOf(
+      PropTypes.shape({
+        courseCode: PropTypes.string.isRequired,
+        courseName: PropTypes.string,
+      }),
+    ),
+    pairs: PropTypes.arrayOf(
+      PropTypes.shape({
+        a: PropTypes.object.isRequired,
+        b: PropTypes.object.isRequired,
+      }),
+    ),
+    pinTargets: PropTypes.arrayOf(PropTypes.string),
+  }),
+};

--- a/src/components/generator/Forms/CourseList/CourseListItemComponent.jsx
+++ b/src/components/generator/Forms/CourseList/CourseListItemComponent.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect } from "react";
 import PropTypes from "prop-types";
 import { ChevronDown, ChevronUp, Palette, Trash2 } from "lucide-react";
 import { CourseColorsContext } from "@/lib/contexts/generator/CourseColorsContext";
-import { clearCoursePins } from "@/lib/generator/pinnedComponents";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -60,7 +59,6 @@ export default function CourseListComponent({
   const handleRemoveClick = () => {
     setOpen(false);
     removeCourse(course);
-    clearCoursePins(course.split(" ")[0] + course.split(" ")[1]);
   };
 
   const handleColorChange = (event) => {

--- a/src/components/generator/Forms/InputFormBottomComponent.jsx
+++ b/src/components/generator/Forms/InputFormBottomComponent.jsx
@@ -3,8 +3,7 @@ import CourseList from "./CourseList/CourseList";
 import PerformanceMetrics from "./Settings/PerformanceMetrics";
 import ExportOptions from "./Settings/ExportOptions";
 import Tips from "./Settings/Tips";
-import { removeCourseData } from "@/lib/generator/courseData";
-import { removePinnedComponent } from "@/lib/generator/pinnedComponents";
+import { removeAddedCourse } from "@/lib/generator/courseActions";
 
 export default function InputFormBottomComponent({
   addedCourses,
@@ -13,18 +12,14 @@ export default function InputFormBottomComponent({
   timetables,
   durations,
   sortOption,
-  generateTimetables,
-  getValidTimetables,
 }) {
   const handleRemoveCourse = (course) => {
-    const cleanCourseCode = course.split(" ").slice(0, 2).join("");
-    setAddedCourses(addedCourses.filter((c) => c !== course));
-    removeCourseData(cleanCourseCode);
-    removePinnedComponent(
-      `${cleanCourseCode} DURATION ${course.split(" ")[2].substring(1)}`,
-    );
-    generateTimetables(sortOption);
-    setTimetables(getValidTimetables());
+    removeAddedCourse(course, {
+      addedCourses,
+      setAddedCourses,
+      setTimetables,
+      sortOption,
+    });
   };
 
   return (
@@ -49,6 +44,4 @@ InputFormBottomComponent.propTypes = {
   timetables: PropTypes.array.isRequired,
   durations: PropTypes.arrayOf(PropTypes.string).isRequired,
   sortOption: PropTypes.string.isRequired,
-  generateTimetables: PropTypes.func.isRequired,
-  getValidTimetables: PropTypes.func.isRequired,
 };

--- a/src/components/generator/Forms/__tests__/GeneratorFeatureInteractions.test.jsx
+++ b/src/components/generator/Forms/__tests__/GeneratorFeatureInteractions.test.jsx
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   getGenerationPerformance: vi.fn(),
   addPinnedComponent: vi.fn(),
   removePinnedComponent: vi.fn(),
+  clearCoursePins: vi.fn(),
   exportCal: vi.fn(),
   trackCourseAddResult: vi.fn(),
   trackScheduleGenerated: vi.fn(),
@@ -57,6 +58,7 @@ vi.mock("@/lib/generator/timetableGeneration/timetableGeneration", () => ({
 vi.mock("@/lib/generator/pinnedComponents", () => ({
   addPinnedComponent: mocks.addPinnedComponent,
   removePinnedComponent: mocks.removePinnedComponent,
+  clearCoursePins: mocks.clearCoursePins,
 }));
 
 vi.mock("@/lib/generator/ExportCal.js", () => ({
@@ -231,8 +233,6 @@ describe("generator feature interactions", () => {
   it("removes a course and regenerates the timetable results", async () => {
     const setAddedCourses = vi.fn();
     const setTimetables = vi.fn();
-    const generateTimetables = vi.fn();
-    const getValidTimetables = vi.fn(() => generatedTimetables);
 
     render(
       <InputFormBottom
@@ -242,8 +242,6 @@ describe("generator feature interactions", () => {
         timetables={generatedTimetables}
         durations={[duration]}
         sortOption="default"
-        generateTimetables={generateTimetables}
-        getValidTimetables={getValidTimetables}
       />,
     );
 
@@ -253,10 +251,8 @@ describe("generator feature interactions", () => {
 
     expect(setAddedCourses).toHaveBeenCalledWith([]);
     expect(mocks.removeCourseData).toHaveBeenCalledWith("COSC1P02");
-    expect(mocks.removePinnedComponent).toHaveBeenCalledWith(
-      "COSC1P02 DURATION 2",
-    );
-    expect(generateTimetables).toHaveBeenCalledWith("default");
+    expect(mocks.clearCoursePins).toHaveBeenCalledWith("COSC1P02");
+    expect(mocks.generateTimetables).toHaveBeenCalledWith("default");
     expect(setTimetables).toHaveBeenCalledWith(generatedTimetables);
   });
 

--- a/src/lib/generator/courseActions.js
+++ b/src/lib/generator/courseActions.js
@@ -1,0 +1,35 @@
+import { removeCourseData } from "@/lib/generator/courseData";
+import { removePinnedComponent } from "@/lib/generator/pinnedComponents";
+import {
+  generateTimetables,
+  getValidTimetables,
+} from "@/lib/generator/timetableGeneration/timetableGeneration";
+
+/**
+ * Removes an added course (by its display label, e.g. "COSC 1P02 D2"), clears
+ * its pinned duration, regenerates timetables and pushes the fresh results.
+ * Shared by the course list and the conflict dialog so removal behaves
+ * identically wherever it is triggered.
+ */
+export const removeAddedCourse = (
+  courseLabel,
+  { addedCourses, setAddedCourses, setTimetables, sortOption },
+) => {
+  const cleanCourseCode = courseLabel.split(" ").slice(0, 2).join("");
+  setAddedCourses(addedCourses.filter((c) => c !== courseLabel));
+  removeCourseData(cleanCourseCode);
+  removePinnedComponent(
+    `${cleanCourseCode} DURATION ${courseLabel.split(" ")[2].substring(1)}`,
+  );
+  generateTimetables(sortOption);
+  setTimetables(getValidTimetables());
+};
+
+/**
+ * Finds the added-course label (e.g. "COSC 1P02 D2") that corresponds to a bare
+ * course code (e.g. "COSC1P02"). Returns undefined if not present.
+ */
+export const findCourseLabelByCode = (addedCourses, courseCode) =>
+  addedCourses.find(
+    (label) => label.split(" ").slice(0, 2).join("") === courseCode,
+  );

--- a/src/lib/generator/courseActions.js
+++ b/src/lib/generator/courseActions.js
@@ -1,5 +1,5 @@
 import { removeCourseData } from "@/lib/generator/courseData";
-import { removePinnedComponent } from "@/lib/generator/pinnedComponents";
+import { clearCoursePins } from "@/lib/generator/pinnedComponents";
 import {
   generateTimetables,
   getValidTimetables,
@@ -7,7 +7,7 @@ import {
 
 /**
  * Removes an added course (by its display label, e.g. "COSC 1P02 D2"), clears
- * its pinned duration, regenerates timetables and pushes the fresh results.
+ * its pins, regenerates timetables and pushes the fresh results.
  * Shared by the course list and the conflict dialog so removal behaves
  * identically wherever it is triggered.
  */
@@ -18,9 +18,7 @@ export const removeAddedCourse = (
   const cleanCourseCode = courseLabel.split(" ").slice(0, 2).join("");
   setAddedCourses(addedCourses.filter((c) => c !== courseLabel));
   removeCourseData(cleanCourseCode);
-  removePinnedComponent(
-    `${cleanCourseCode} DURATION ${courseLabel.split(" ")[2].substring(1)}`,
-  );
+  clearCoursePins(cleanCourseCode);
   generateTimetables(sortOption);
   setTimetables(getValidTimetables());
 };

--- a/src/lib/generator/createCalendarEvents.js
+++ b/src/lib/generator/createCalendarEvents.js
@@ -8,6 +8,10 @@ export const createCalendarEvents = (
 ) => {
   const newEvents = [];
 
+  // Set of "courseCode|componentId" keys for components that are part of an
+  // unavoidable conflict, so their calendar events can be highlighted.
+  const conflictKeys = timetable?.conflictKeys;
+
   /*
     Note: In cases where we have multiple main course components, (such as two LECs)
     the components will have the same ID and as such we have to append an index counter
@@ -31,6 +35,8 @@ export const createCalendarEvents = (
   ) => {
     const uniqueId = getUniqueId(component.id);
     const customColor = courseColors[course.courseCode] || defaultColor;
+    const isConflicting =
+      conflictKeys?.has(`${course.courseCode}|${component.id}`) ?? false;
     const event = {
       id: uniqueId,
       title: `${course.courseCode} ${component.type} ${
@@ -47,6 +53,7 @@ export const createCalendarEvents = (
         courseName: course.courseName || "",
         isPinned: component.pinned,
         isMain: component.isMain ?? false,
+        isConflicting,
       },
     };
 

--- a/src/lib/generator/timetableGeneration/timetableGeneration.js
+++ b/src/lib/generator/timetableGeneration/timetableGeneration.js
@@ -5,12 +5,18 @@ import {
 
 import {
   emitNoValidTimetablesFound,
+  emitTimetableConflict,
+  clearConflictFlag,
   clearOverriddenFlag,
   clearTruncationFlag,
   sortTimetableIndexReset,
 } from "./utils/UIEventsUtils";
 
-import { isTimetableValid } from "./utils/validateUtils";
+import {
+  isTimetableValid,
+  findTimetableConflicts,
+} from "./utils/validateUtils";
+import { buildConflictFallback } from "./utils/conflictUtils";
 import { calculateWaitingTime, calculateClassDays } from "./utils/sortUtils";
 import { getCourseData } from "../courseData";
 import { getTimeSlots } from "../timeSlots";
@@ -52,6 +58,7 @@ export const generateTimetables = (sortOption) => {
       allCourseCombinations.some((combinations) => combinations.length === 0)
     ) {
       validTimetables.push({ courses: [] });
+      clearConflictFlag();
       return;
     }
 
@@ -81,7 +88,33 @@ export const generateTimetables = (sortOption) => {
     }
 
     if (validTimetables.length === 0) {
-      emitNoValidTimetablesFound();
+      // Last resort: every course has at least one valid section combination
+      // (the "course not offered" case returned earlier), yet no combination
+      // across courses is conflict-free. Rather than wiping the calendar, show
+      // the least-conflicting timetable and surface the clash to the user.
+      const fallback = buildConflictFallback(
+        allPossibleTimetables,
+        findTimetableConflicts,
+      );
+
+      if (fallback) {
+        // Surface every timetable tied for the fewest conflicts so the user can
+        // still browse variations (e.g. different seminars) that don't change
+        // the unavoidable clash.
+        fallback.timetables.forEach(({ timetable, conflictKeys }) => {
+          validTimetables.push({
+            courses: timetable,
+            hasConflicts: true,
+            conflictKeys,
+          });
+        });
+        emitTimetableConflict(fallback.conflictInfo);
+      } else {
+        emitNoValidTimetablesFound();
+        clearConflictFlag();
+      }
+    } else {
+      clearConflictFlag();
     }
   } finally {
     performanceMetrics.generationEndTime = performance.now();

--- a/src/lib/generator/timetableGeneration/utils/UIEventsUtils.js
+++ b/src/lib/generator/timetableGeneration/utils/UIEventsUtils.js
@@ -9,6 +9,14 @@ export const emitNoValidTimetablesFound = () => {
   });
 };
 
+export const emitTimetableConflict = (conflictInfo) => {
+  eventBus.emit("conflict", conflictInfo);
+};
+
+export const clearConflictFlag = () => {
+  eventBus.emit("conflict", null);
+};
+
 let emitTimetableOverriddenCooldown = 0;
 
 export const emitTimetableOverridden = () => {

--- a/src/lib/generator/timetableGeneration/utils/conflictUtils.js
+++ b/src/lib/generator/timetableGeneration/utils/conflictUtils.js
@@ -1,0 +1,85 @@
+// Derives the highlight keys and user-facing summary for a single timetable's
+// set of conflicting component pairs.
+const buildConflictData = (conflicts) => {
+  const conflictKeys = new Set();
+  const involvedCoursesMap = new Map();
+  const pinTargetMap = new Map();
+  const pairs = [];
+
+  const componentKey = (comp) => `${comp.courseCode}|${comp.componentId}`;
+  const trackCourse = (comp) => {
+    conflictKeys.add(componentKey(comp));
+    if (!involvedCoursesMap.has(comp.courseCode)) {
+      involvedCoursesMap.set(comp.courseCode, {
+        courseCode: comp.courseCode,
+        courseName: comp.courseName || "",
+      });
+    }
+    // "COSC1P02 MAIN 3591102" — pins the exact conflicting section so the
+    // arrangement is locked and shows a pin icon when the user ignores it.
+    const pin = `${comp.courseCode} ${comp.pinType} ${comp.baseComponentId}`;
+    pinTargetMap.set(pin, pin);
+  };
+
+  for (const { a, b } of conflicts) {
+    trackCourse(a);
+    trackCourse(b);
+    pairs.push({
+      a: { courseCode: a.courseCode, type: a.type, days: a.days, time: a.time },
+      b: { courseCode: b.courseCode, type: b.type, days: b.days, time: b.time },
+    });
+  }
+
+  return {
+    conflictKeys,
+    involvedCourses: Array.from(involvedCoursesMap.values()),
+    pairs,
+    pinTargets: Array.from(pinTargetMap.values()),
+  };
+};
+
+/**
+ * Builds the "least-conflicting" fallback shown when no conflict-free timetable
+ * exists. Returns *every* timetable tied for the fewest cross-course conflicts
+ * so the user can still page through the variations that don't affect the
+ * unavoidable clash (e.g. different seminars), plus the data the UI needs to
+ * highlight the clashing components and explain them.
+ *
+ * Returns null when there is nothing meaningful to surface (no candidates, or
+ * the best candidates have no cross-course conflicts to report).
+ */
+export const buildConflictFallback = (allPossibleTimetables, findConflicts) => {
+  let minConflictCount = Infinity;
+  let bestGroup = [];
+
+  for (const timetable of allPossibleTimetables) {
+    const conflicts = findConflicts(timetable);
+    if (conflicts.length === 0) continue; // unreachable for a valid timetable
+    if (conflicts.length < minConflictCount) {
+      minConflictCount = conflicts.length;
+      bestGroup = [{ timetable, conflicts }];
+    } else if (conflicts.length === minConflictCount) {
+      bestGroup.push({ timetable, conflicts });
+    }
+  }
+
+  if (bestGroup.length === 0) {
+    return null;
+  }
+
+  // The summary/pins shown in the dialog are taken from a representative
+  // candidate; tied candidates share the same unavoidable clash.
+  const representative = buildConflictData(bestGroup[0].conflicts);
+
+  return {
+    timetables: bestGroup.map(({ timetable, conflicts }) => ({
+      timetable,
+      conflictKeys: buildConflictData(conflicts).conflictKeys,
+    })),
+    conflictInfo: {
+      involvedCourses: representative.involvedCourses,
+      pairs: representative.pairs,
+      pinTargets: representative.pinTargets,
+    },
+  };
+};

--- a/src/lib/generator/timetableGeneration/utils/validateUtils.js
+++ b/src/lib/generator/timetableGeneration/utils/validateUtils.js
@@ -15,7 +15,10 @@ const flattenTimetableComponents = (timetable) => {
 
   for (const course of timetable) {
     const taggedComponents = [
-      ...course.mainComponents.map((component) => ({ component, pinType: "MAIN" })),
+      ...course.mainComponents.map((component) => ({
+        component,
+        pinType: "MAIN",
+      })),
       { component: course.secondaryComponents.lab, pinType: "LAB" },
       { component: course.secondaryComponents.tutorial, pinType: "TUT" },
       { component: course.secondaryComponents.seminar, pinType: "SEM" },

--- a/src/lib/generator/timetableGeneration/utils/validateUtils.js
+++ b/src/lib/generator/timetableGeneration/utils/validateUtils.js
@@ -1,24 +1,27 @@
 import { timeToSlot } from "./timeUtils";
 import { getBaseComponentId } from "./componentIDUtils";
 
-export const isTimetableValid = (timetable) => {
-  const timeRegex = /[a-zA-Z]/;
-  const dateRangesOverlap = (start1, end1, start2, end2) =>
-    start1 <= end2 && start2 <= end1;
-  const timeSlotsOverlap = (start1, end1, start2, end2) =>
-    start1 < end2 && start2 < end1;
+const dateRangesOverlap = (start1, end1, start2, end2) =>
+  start1 <= end2 && start2 <= end1;
+const timeSlotsOverlap = (start1, end1, start2, end2) =>
+  start1 < end2 && start2 < end1;
 
+// Flattens a timetable into a list of scheduled component descriptors, skipping
+// components without a concrete time (e.g. fully asynchronous/online sections).
+// pinType records how the component would be pinned (MAIN/LAB/TUT/SEM).
+const flattenTimetableComponents = (timetable) => {
+  const timeRegex = /[a-zA-Z]/;
   const allComponents = [];
 
   for (const course of timetable) {
-    const components = [
-      ...course.mainComponents,
-      course.secondaryComponents.lab,
-      course.secondaryComponents.tutorial,
-      course.secondaryComponents.seminar,
-    ].filter(Boolean);
+    const taggedComponents = [
+      ...course.mainComponents.map((component) => ({ component, pinType: "MAIN" })),
+      { component: course.secondaryComponents.lab, pinType: "LAB" },
+      { component: course.secondaryComponents.tutorial, pinType: "TUT" },
+      { component: course.secondaryComponents.seminar, pinType: "SEM" },
+    ].filter(({ component }) => Boolean(component));
 
-    for (const component of components) {
+    for (const { component, pinType } of taggedComponents) {
       const { days, time, startDate, endDate } = component.schedule;
       if (!time || timeRegex.test(time)) continue;
 
@@ -31,9 +34,13 @@ export const isTimetableValid = (timetable) => {
 
       allComponents.push({
         courseCode: course.courseCode,
+        courseName: course.courseName || "",
         componentId: component.id,
+        type: component.type,
+        pinType,
         baseComponentId: getBaseComponentId(component.id),
         days: daysArray,
+        time,
         startSlot,
         endSlot,
         startDate,
@@ -42,36 +49,66 @@ export const isTimetableValid = (timetable) => {
     }
   }
 
+  return allComponents;
+};
+
+const componentsConflict = (comp1, comp2) => {
+  if (
+    !dateRangesOverlap(
+      comp1.startDate,
+      comp1.endDate,
+      comp2.startDate,
+      comp2.endDate,
+    )
+  )
+    return false;
+
+  const commonDays = comp1.days.filter((day) => comp2.days.includes(day));
+  if (commonDays.length === 0) return false;
+
+  return timeSlotsOverlap(
+    comp1.startSlot,
+    comp1.endSlot,
+    comp2.startSlot,
+    comp2.endSlot,
+  );
+};
+
+export const isTimetableValid = (timetable) => {
+  const allComponents = flattenTimetableComponents(timetable);
+
   for (let i = 0; i < allComponents.length; i++) {
     for (let j = i + 1; j < allComponents.length; j++) {
-      const comp1 = allComponents[i];
-      const comp2 = allComponents[j];
-
-      if (
-        !dateRangesOverlap(
-          comp1.startDate,
-          comp1.endDate,
-          comp2.startDate,
-          comp2.endDate,
-        )
-      )
-        continue;
-
-      const commonDays = comp1.days.filter((day) => comp2.days.includes(day));
-      if (commonDays.length === 0) continue;
-
-      if (
-        timeSlotsOverlap(
-          comp1.startSlot,
-          comp1.endSlot,
-          comp2.startSlot,
-          comp2.endSlot,
-        )
-      ) {
+      if (componentsConflict(allComponents[i], allComponents[j])) {
         return false;
       }
     }
   }
 
   return true;
+};
+
+/**
+ * Returns every overlapping pair of components in a timetable. Unlike
+ * isTimetableValid this does a full scan (no short-circuit) so the result can be
+ * used to highlight and explain unavoidable conflicts to the user.
+ */
+export const findTimetableConflicts = (timetable) => {
+  const allComponents = flattenTimetableComponents(timetable);
+  const conflicts = [];
+
+  for (let i = 0; i < allComponents.length; i++) {
+    for (let j = i + 1; j < allComponents.length; j++) {
+      const comp1 = allComponents[i];
+      const comp2 = allComponents[j];
+      // Components of the same course are expected to be scheduled together and
+      // are not treated as user-facing conflicts.
+      if (comp1.courseCode === comp2.courseCode) continue;
+      if (componentsConflict(comp1, comp2)) {
+        conflicts.push({ a: comp1, b: comp2 });
+      }
+    }
+  }
+
+  return conflicts;
 };

--- a/src/pages/GeneratorPage.jsx
+++ b/src/pages/GeneratorPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   NavbarComponent,
   CalendarComponent,
@@ -9,15 +9,46 @@ import { useIsBelowMedium } from "@/lib/utils/screenSizeUtils";
 import { CourseDetailsProvider } from "@/lib/contexts/generator/CourseDetailsContext";
 import { CourseColorsProvider } from "@/lib/contexts/generator/CourseColorsContext";
 import IntroGuideWidget from "@/components/generator/Dialogs/IntroGuideWidget";
+import ConflictDialog from "@/components/generator/Dialogs/ConflictDialog";
 import { trackPageView } from "@/lib/metrics";
+import { clearAllCourseData } from "@/lib/generator/courseData";
+import {
+  clearAllPins,
+  addPinnedComponent,
+  getPinnedComponents,
+} from "@/lib/generator/pinnedComponents";
 import {
   generateTimetables,
   getValidTimetables,
 } from "@/lib/generator/timetableGeneration/timetableGeneration";
-import { clearAllCourseData } from "@/lib/generator/courseData";
-import { clearAllPins } from "@/lib/generator/pinnedComponents";
+import {
+  removeAddedCourse,
+  findCourseLabelByCode,
+} from "@/lib/generator/courseActions";
+import eventBus from "@/lib/eventBus";
 import FooterComponent from "@/components/sitewide/FooterComponent";
 import { usePageMeta } from "@/lib/usePageMeta";
+
+const conflictSignature = (info) =>
+  info
+    ? info.involvedCourses
+        .map((c) => c.courseCode)
+        .sort()
+        .join(",")
+    : null;
+
+// A conflict is "acknowledged" (kept hidden) only while it matches the exact
+// set of courses the user pinned AND every one of those pins is still in place.
+// Unpinning an overlapped component drops a pin, so the dialog reopens.
+const isConflictAcknowledged = (acknowledged, info) => {
+  if (!acknowledged) return false;
+  if (acknowledged.signature !== conflictSignature(info)) return false;
+  if (!acknowledged.pinTargets || acknowledged.pinTargets.length === 0) {
+    return true;
+  }
+  const pinned = getPinnedComponents();
+  return acknowledged.pinTargets.every((pin) => pinned.includes(pin));
+};
 
 function GeneratorPage() {
   usePageMeta({
@@ -38,7 +69,80 @@ function GeneratorPage() {
   const [durations, setDurations] = useState([]);
   const [sortOption, setSortOption] = useState("");
   const [addedCourses, setAddedCourses] = useState([]);
+  const [conflictInfo, setConflictInfo] = useState(null);
+  const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
+  const conflictInfoRef = useRef(null);
+  const acknowledgedRef = useRef(null);
   const isBelowMedium = useIsBelowMedium();
+
+  useEffect(() => {
+    conflictInfoRef.current = conflictInfo;
+  }, [conflictInfo]);
+
+  // Surface unavoidable conflicts emitted by the generator. The dialog opens
+  // automatically for a new conflict, stays closed once "Pin & Ignore" has
+  // acknowledged that exact set of courses, and can be reopened from the
+  // calendar's conflict indicator.
+  useEffect(() => {
+    const handleConflict = (info) => {
+      setConflictInfo(info);
+      if (!info) {
+        // Conflict resolved: forget the acknowledgement so a brand-new conflict
+        // (even with the same courses) warns again. Generation emits exactly one
+        // terminal conflict state, so "Pin & Ignore" + regeneration re-emits the
+        // same signature (kept closed) rather than a transient null.
+        acknowledgedRef.current = null;
+        setConflictDialogOpen(false);
+        return;
+      }
+      if (!isConflictAcknowledged(acknowledgedRef.current, info)) {
+        setConflictDialogOpen(true);
+      }
+    };
+    const handleOpenConflictDialog = () => {
+      if (conflictInfoRef.current) {
+        setConflictDialogOpen(true);
+      }
+    };
+    eventBus.on("conflict", handleConflict);
+    eventBus.on("openConflictDialog", handleOpenConflictDialog);
+    return () => {
+      eventBus.off("conflict", handleConflict);
+      eventBus.off("openConflictDialog", handleOpenConflictDialog);
+    };
+  }, []);
+
+  const handlePinAndIgnoreConflict = () => {
+    const info = conflictInfoRef.current;
+    const pinTargets = info?.pinTargets ?? [];
+    acknowledgedRef.current = {
+      signature: conflictSignature(info),
+      pinTargets,
+    };
+    setConflictDialogOpen(false);
+
+    // Lock the conflicting sections in place so they display a pin icon and the
+    // arrangement survives further regeneration. Unpinning any of them later
+    // drops a pin, which reopens this dialog (see isConflictAcknowledged).
+    if (pinTargets.length) {
+      pinTargets.forEach((pin) => addPinnedComponent(pin));
+      generateTimetables(sortOption);
+      setTimetables(getValidTimetables());
+    }
+  };
+
+  const handleRemoveConflictCourse = (courseCode) => {
+    const courseLabel = findCourseLabelByCode(addedCourses, courseCode);
+    if (!courseLabel) return;
+    // Regeneration emits a fresh "conflict" event (null or a new set), which
+    // updates or closes the dialog via handleConflict above.
+    removeAddedCourse(courseLabel, {
+      addedCourses,
+      setAddedCourses,
+      setTimetables,
+      sortOption,
+    });
+  };
 
   // Clear all state when component unmounts
   useEffect(() => {
@@ -79,8 +183,6 @@ function GeneratorPage() {
                         timetables={timetables}
                         durations={durations}
                         sortOption={sortOption}
-                        generateTimetables={generateTimetables}
-                        getValidTimetables={getValidTimetables}
                       />
                     </div>
                   )}
@@ -108,14 +210,18 @@ function GeneratorPage() {
                       timetables={timetables}
                       durations={durations}
                       sortOption={sortOption}
-                      generateTimetables={generateTimetables}
-                      getValidTimetables={getValidTimetables}
                     />
                   </div>
                 </div>
               )}
             </div>
             <IntroGuideWidget />
+            <ConflictDialog
+              open={conflictDialogOpen}
+              onClose={handlePinAndIgnoreConflict}
+              conflictInfo={conflictInfo}
+              onRemoveCourse={handleRemoveConflictCourse}
+            />
             <FooterComponent />
           </div>
         </div>

--- a/src/styles/generator/CustomCalendar.css
+++ b/src/styles/generator/CustomCalendar.css
@@ -109,6 +109,20 @@
   outline: 0;
 }
 
+#Calendar .fc .fc-event-conflict {
+  border: 2px solid #dc2626 !important;
+  box-shadow: 0 0 0 1px #dc2626;
+  outline: none;
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(220, 38, 38, 0.28),
+    rgba(220, 38, 38, 0.28) 6px,
+    rgba(220, 38, 38, 0) 6px,
+    rgba(220, 38, 38, 0) 12px
+  );
+  z-index: 5;
+}
+
 #Calendar .fc .fc-highlight {
   background: transparent !important;
 }


### PR DESCRIPTION

<img width="1160" height="727" alt="image" src="https://github.com/user-attachments/assets/af1e9d1c-a36c-4658-ac84-711d0c483e66" />

Previously, if the added courses could never be scheduled without an overlap ), the generator produced zero timetables and cleared the calendar with a "No valid timetables" error, which was not very user friendly.

Now, normal generation is unchanged (it still only ever shows conflict-free options). But when a clash is genuinely unavoidable it surfaces the closest-to-valid timetable(s), highlights the conflict, and let the user resolve or accept it.

### What's included
- Conflict detection & fallback: findTimetableConflicts returns all overlapping cross-course pairs; buildConflictFallback keeps every timetable tied for the fewest conflicts, so you can still page through variations that don't affect the clash (e.g. different seminars).

- Conflict dialog:: dims the page, scrolls/frames to the conflict, and floats a popup beneath it (desktop) or a bottom sheet (mobile). From there the user can Remove a course or Pin & Ignore.

- Pin & Ignore pins the clashing sections (shows the pin icon) and keeps the timetable. The dialog reopens if the user later unpins one of those components.
Notes