### PR TITLE
Add shareable / saveable timetables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "fflate": "^0.8.3",
         "lucide-react": "^0.562.0",
         "notistack": "^3.0.1",
         "prop-types": "^15.8.1",
@@ -4856,6 +4857,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "fflate": "^0.8.3",
     "lucide-react": "^0.562.0",
     "notistack": "^3.0.1",
     "prop-types": "^15.8.1",

--- a/src/components/generator/Calendar/CalendarComponent.jsx
+++ b/src/components/generator/Calendar/CalendarComponent.jsx
@@ -53,6 +53,9 @@ export default function CalendarComponent({
   setSelectedDuration,
   durations,
   sortOption,
+  currentTimetableIndex,
+  setCurrentTimetableIndex,
+  onTimeBlockChange,
 }) {
   const { enqueueSnackbar } = useSnackbar();
   const calendarRef = React.useRef(null);
@@ -60,7 +63,6 @@ export default function CalendarComponent({
   const currentTimetableIndexRef = React.useRef(0);
   const courseColorsRef = React.useRef({});
   const [events, setEvents] = useState([]);
-  const [currentTimetableIndex, setCurrentTimetableIndex] = useState(0);
   const [viewRange, setViewRange] = useState(null);
   const { setCourseDetails } = useContext(CourseDetailsContext);
   const { courseColors, setCalendarUpdateHandler, getDefaultColorForCourse } =
@@ -117,12 +119,12 @@ export default function CalendarComponent({
     if (currentTimetableIndex >= visibleTimetables.length) {
       setCurrentTimetableIndex(0);
     }
-  }, [currentTimetableIndex, visibleTimetables.length]);
+  }, [currentTimetableIndex, visibleTimetables.length, setCurrentTimetableIndex]);
 
   const handleLast = useCallback(() => {
     if (visibleTimetables.length === 0) return;
     setCurrentTimetableIndex(visibleTimetables.length - 1);
-  }, [visibleTimetables.length]);
+  }, [visibleTimetables.length, setCurrentTimetableIndex]);
 
   const updateCalendarEvents = useCallback(() => {
     const currentTimetables = timetablesRef.current;
@@ -217,7 +219,7 @@ export default function CalendarComponent({
         variant: "info",
       });
     },
-    [enqueueSnackbar, setSelectedDuration],
+    [enqueueSnackbar, setSelectedDuration, setCurrentTimetableIndex],
   );
 
   useEffect(() => {
@@ -366,6 +368,7 @@ export default function CalendarComponent({
         setCurrentTimetableIndex,
         setTimetables,
         sortOption,
+        onTimeBlockChange,
       );
     }
   };
@@ -394,6 +397,7 @@ export default function CalendarComponent({
             setCurrentTimetableIndex,
             setTimetables,
             sortOption,
+            onTimeBlockChange,
           );
         });
       } else if (blockToRename.id) {
@@ -403,6 +407,7 @@ export default function CalendarComponent({
           setCurrentTimetableIndex,
           setTimetables,
           sortOption,
+          onTimeBlockChange,
         );
       }
       setBlockToRename(null);
@@ -432,6 +437,7 @@ export default function CalendarComponent({
       setBlockToRename,
       setRenameAnchorEl,
       setRenameAnchorPosition,
+      onTimeBlockChange,
     );
   };
 
@@ -578,4 +584,7 @@ CalendarComponent.propTypes = {
   setSelectedDuration: PropTypes.func.isRequired,
   durations: PropTypes.arrayOf(PropTypes.string).isRequired,
   sortOption: PropTypes.string.isRequired,
+  currentTimetableIndex: PropTypes.number.isRequired,
+  setCurrentTimetableIndex: PropTypes.func.isRequired,
+  onTimeBlockChange: PropTypes.func.isRequired,
 };

--- a/src/components/generator/Calendar/CalendarComponent.jsx
+++ b/src/components/generator/Calendar/CalendarComponent.jsx
@@ -119,7 +119,11 @@ export default function CalendarComponent({
     if (currentTimetableIndex >= visibleTimetables.length) {
       setCurrentTimetableIndex(0);
     }
-  }, [currentTimetableIndex, visibleTimetables.length, setCurrentTimetableIndex]);
+  }, [
+    currentTimetableIndex,
+    visibleTimetables.length,
+    setCurrentTimetableIndex,
+  ]);
 
   const handleLast = useCallback(() => {
     if (visibleTimetables.length === 0) return;

--- a/src/components/generator/Calendar/__tests__/CalendarComponent.test.jsx
+++ b/src/components/generator/Calendar/__tests__/CalendarComponent.test.jsx
@@ -187,8 +187,7 @@ function renderCalendar(props = {}) {
   // currentTimetableIndex is owned by the parent (GeneratorPage) now, so the
   // test hosts it in a small stateful harness to drive the navigation buttons.
   function CalendarHarness({ timetables = [timetable], ...rest }) {
-    const [currentTimetableIndex, setCurrentTimetableIndex] =
-      React.useState(0);
+    const [currentTimetableIndex, setCurrentTimetableIndex] = React.useState(0);
 
     return (
       <CalendarComponent

--- a/src/components/generator/Calendar/__tests__/CalendarComponent.test.jsx
+++ b/src/components/generator/Calendar/__tests__/CalendarComponent.test.jsx
@@ -182,6 +182,33 @@ function renderCalendar(props = {}) {
   const setSelectedDuration = vi.fn();
   const setCourseDetails = vi.fn();
   const setCalendarUpdateHandler = vi.fn();
+  const onTimeBlockChange = vi.fn();
+
+  // currentTimetableIndex is owned by the parent (GeneratorPage) now, so the
+  // test hosts it in a small stateful harness to drive the navigation buttons.
+  function CalendarHarness({ timetables = [timetable], ...rest }) {
+    const [currentTimetableIndex, setCurrentTimetableIndex] =
+      React.useState(0);
+
+    return (
+      <CalendarComponent
+        timetables={timetables}
+        setTimetables={setTimetables}
+        selectedDuration={duration}
+        setSelectedDuration={setSelectedDuration}
+        durations={[duration]}
+        sortOption="default"
+        currentTimetableIndex={currentTimetableIndex}
+        setCurrentTimetableIndex={setCurrentTimetableIndex}
+        onTimeBlockChange={onTimeBlockChange}
+        {...rest}
+      />
+    );
+  }
+
+  CalendarHarness.propTypes = {
+    timetables: PropTypes.array,
+  };
 
   render(
     <CourseDetailsContext.Provider
@@ -196,20 +223,17 @@ function renderCalendar(props = {}) {
           setCalendarUpdateHandler,
         }}
       >
-        <CalendarComponent
-          timetables={[timetable]}
-          setTimetables={setTimetables}
-          selectedDuration={duration}
-          setSelectedDuration={setSelectedDuration}
-          durations={[duration]}
-          sortOption="default"
-          {...props}
-        />
+        <CalendarHarness {...props} />
       </CourseColorsContext.Provider>
     </CourseDetailsContext.Provider>,
   );
 
-  return { setTimetables, setSelectedDuration, setCalendarUpdateHandler };
+  return {
+    setTimetables,
+    setSelectedDuration,
+    setCalendarUpdateHandler,
+    onTimeBlockChange,
+  };
 }
 
 function CalendarUpdateHandlerProbe() {

--- a/src/components/generator/Calendar/utils/eventHandlerUtils.js
+++ b/src/components/generator/Calendar/utils/eventHandlerUtils.js
@@ -66,6 +66,7 @@ export const handleTimeBlockRemoval = (
   setCurrentTimetableIndex,
   setTimetables,
   sortOption,
+  onTimeBlockChange,
 ) => {
   const blockId = clickInfo.event.id.replace("block-", "");
   const blockEvent = getTimeBlockEvents().find((block) => block.id === blockId);
@@ -94,6 +95,7 @@ export const handleTimeBlockRemoval = (
   setCurrentTimetableIndex(0);
   generateTimetables(sortOption);
   setTimetables(getValidTimetables());
+  onTimeBlockChange?.();
 };
 
 export const handleBlockedSlotRename = (
@@ -102,12 +104,14 @@ export const handleBlockedSlotRename = (
   setCurrentTimetableIndex,
   setTimetables,
   sortOption,
+  onTimeBlockChange,
 ) => {
   updateTimeBlockEventTitle(blockId, newTitle);
 
   setCurrentTimetableIndex(0);
   generateTimetables(sortOption);
   setTimetables(getValidTimetables());
+  onTimeBlockChange?.();
 };
 
 // Extract the complex logic for handling calendar selection
@@ -120,6 +124,7 @@ export const handleCalendarSelection = (
   setBlockToRename,
   setRenameAnchorEl,
   setRenameAnchorPosition,
+  onTimeBlockChange,
 ) => {
   const startDateTime = new Date(selectInfo.startStr);
   const endDateTime = new Date(selectInfo.endStr);
@@ -230,5 +235,6 @@ export const handleCalendarSelection = (
     setCurrentTimetableIndex(0);
     generateTimetables(sortOption);
     setTimetables(getValidTimetables());
+    onTimeBlockChange?.();
   }
 };

--- a/src/components/generator/Export/ExportCalendarButton.jsx
+++ b/src/components/generator/Export/ExportCalendarButton.jsx
@@ -76,7 +76,7 @@ export default function ExportCalendarButton({ timetables, durations }) {
         onClick={handleExport}
         className="transition-none"
       >
-        Export Calendar
+        Export To Calendar App
       </Button>
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent>

--- a/src/components/generator/Export/ShareTimetableButton.jsx
+++ b/src/components/generator/Export/ShareTimetableButton.jsx
@@ -1,0 +1,80 @@
+import PropTypes from "prop-types";
+import { useSnackbar } from "notistack";
+import { Share2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import MultiLineSnackbar from "@/components/sitewide/MultiLineSnackbar";
+
+// Copies text to the clipboard, falling back to a temporary textarea for
+// browsers/contexts where the async Clipboard API is unavailable (e.g. http).
+const copyToClipboard = async (text) => {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  const succeeded = document.execCommand("copy");
+  document.body.removeChild(textarea);
+  if (!succeeded) {
+    throw new Error("Clipboard copy command was rejected");
+  }
+};
+
+export default function ShareTimetableButton({ timetables }) {
+  const { enqueueSnackbar } = useSnackbar();
+
+  // The URL only encodes a shareable snapshot once a real timetable exists.
+  const canShare =
+    timetables.length > 0 && (timetables[0]?.courses?.length ?? 0) > 0;
+
+  const handleShare = async () => {
+    try {
+      await copyToClipboard(window.location.href);
+      enqueueSnackbar(
+        <MultiLineSnackbar
+          className="text-center"
+          message={
+            "Successfully copied link to clipboard!\nShare it with others or write it to open this timetable again at a later time."
+          }
+        />,
+        { variant: "success" },
+      );
+    } catch (error) {
+      enqueueSnackbar(
+        <MultiLineSnackbar
+          className="text-center"
+          message={
+            "Couldn't copy the link automatically.\nCopy the URL from your address bar instead."
+          }
+        />,
+        { variant: "error" },
+      );
+    }
+  };
+
+  return (
+    <Button
+      onClick={handleShare}
+      disabled={!canShare}
+      className="transition-none"
+      title={
+        canShare
+          ? "Copy a link to this exact timetable"
+          : "Add a course to create a shareable timetable"
+      }
+    >
+      <Share2 />
+      Share / Save Timetable
+    </Button>
+  );
+}
+
+ShareTimetableButton.propTypes = {
+  timetables: PropTypes.array.isRequired,
+};

--- a/src/components/generator/Export/ShareTimetableButton.jsx
+++ b/src/components/generator/Export/ShareTimetableButton.jsx
@@ -40,7 +40,7 @@ export default function ShareTimetableButton({ timetables }) {
         <MultiLineSnackbar
           className="text-center"
           message={
-            "Successfully copied link to clipboard!\nShare it with others or write it to open this timetable again at a later time."
+            "Successfully copied link to clipboard!\nShare it with others or write it down to open this timetable again at a later time."
           }
         />,
         { variant: "success" },

--- a/src/components/generator/Forms/CourseSearch/TermSelectComponent.jsx
+++ b/src/components/generator/Forms/CourseSearch/TermSelectComponent.jsx
@@ -7,15 +7,19 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-export default function TermSelectComponent({ term, onTermChange }) {
+export default function TermSelectComponent({
+  term,
+  onTermChange,
+  disabled = false,
+}) {
   function handleTermChange(selectedTerm) {
     onTermChange(selectedTerm);
   }
 
   return (
     <div id="termSelectComponent">
-      <Select value={term} onValueChange={handleTermChange}>
-        <SelectTrigger className="w-full" aria-label="Term">
+      <Select value={term} onValueChange={handleTermChange} disabled={disabled}>
+        <SelectTrigger className="w-full" aria-label="Term" disabled={disabled}>
           <SelectValue placeholder="Select Term" />
         </SelectTrigger>
         <SelectContent>
@@ -31,4 +35,5 @@ export default function TermSelectComponent({ term, onTermChange }) {
 TermSelectComponent.propTypes = {
   term: PropTypes.string.isRequired,
   onTermChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
 };

--- a/src/components/generator/Forms/CourseSearch/TermSelectComponent.jsx
+++ b/src/components/generator/Forms/CourseSearch/TermSelectComponent.jsx
@@ -23,8 +23,10 @@ export default function TermSelectComponent({
           <SelectValue placeholder="Select Term" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="FW">Fall/Winter 2026</SelectItem>
-          <SelectItem value="SP">Spring 2026</SelectItem>
+          <SelectItem value="FW">Fall/Winter 2026-27</SelectItem>
+          <SelectItem value="SP" disabled>
+            Spring 2026
+          </SelectItem>
           <SelectItem value="SU">Summer 2026</SelectItem>
         </SelectContent>
       </Select>

--- a/src/components/generator/Forms/CourseSearch/TimeTableSelectComponent.jsx
+++ b/src/components/generator/Forms/CourseSearch/TimeTableSelectComponent.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import {
   Select,
@@ -8,11 +7,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-export default function TimetableSelectComponent({ onTableChange }) {
-  const [timetable, setTimetable] = React.useState("UG");
-
+export default function TimetableSelectComponent({ timetable, onTableChange }) {
   function handleTimetableChange(selectedTimetable) {
-    setTimetable(selectedTimetable);
     onTableChange(selectedTimetable);
   }
 
@@ -34,5 +30,6 @@ export default function TimetableSelectComponent({ onTableChange }) {
 }
 
 TimetableSelectComponent.propTypes = {
+  timetable: PropTypes.string.isRequired,
   onTableChange: PropTypes.func.isRequired,
 };

--- a/src/components/generator/Forms/CourseSearch/TimeTableSelectComponent.jsx
+++ b/src/components/generator/Forms/CourseSearch/TimeTableSelectComponent.jsx
@@ -23,7 +23,11 @@ export default function TimetableSelectComponent({
         onValueChange={handleTimetableChange}
         disabled={disabled}
       >
-        <SelectTrigger className="w-full" aria-label="Timetable" disabled={disabled}>
+        <SelectTrigger
+          className="w-full"
+          aria-label="Timetable"
+          disabled={disabled}
+        >
           <SelectValue placeholder="Select Timetable" />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/generator/Forms/CourseSearch/TimeTableSelectComponent.jsx
+++ b/src/components/generator/Forms/CourseSearch/TimeTableSelectComponent.jsx
@@ -7,15 +7,23 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-export default function TimetableSelectComponent({ timetable, onTableChange }) {
+export default function TimetableSelectComponent({
+  timetable,
+  onTableChange,
+  disabled = false,
+}) {
   function handleTimetableChange(selectedTimetable) {
     onTableChange(selectedTimetable);
   }
 
   return (
     <div>
-      <Select value={timetable} onValueChange={handleTimetableChange}>
-        <SelectTrigger className="w-full" aria-label="Timetable">
+      <Select
+        value={timetable}
+        onValueChange={handleTimetableChange}
+        disabled={disabled}
+      >
+        <SelectTrigger className="w-full" aria-label="Timetable" disabled={disabled}>
           <SelectValue placeholder="Select Timetable" />
         </SelectTrigger>
         <SelectContent>
@@ -32,4 +40,5 @@ export default function TimetableSelectComponent({ timetable, onTableChange }) {
 TimetableSelectComponent.propTypes = {
   timetable: PropTypes.string.isRequired,
   onTableChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
 };

--- a/src/components/generator/Forms/InputFormTopComponent.jsx
+++ b/src/components/generator/Forms/InputFormTopComponent.jsx
@@ -23,11 +23,13 @@ export default function InputFormTop({
   setSortOption,
   addedCourses,
   setAddedCourses,
+  timetableType,
+  setTimetableType,
+  term,
+  setTerm,
 }) {
   const { enqueueSnackbar } = useSnackbar();
-  const [term, setTerm] = useState("FW");
   const [courseValue, setCourseValue] = useState("");
-  const [timetableType, setTimetableType] = useState("UG");
   const [courseOptions, setCourseOptions] = useState([]);
   const [sortChoice, setSortChoice] = useState("default");
   const requestBlock = useRef(false);
@@ -313,4 +315,8 @@ InputFormTop.propTypes = {
   setSortOption: PropTypes.func.isRequired,
   addedCourses: PropTypes.arrayOf(PropTypes.string).isRequired,
   setAddedCourses: PropTypes.func.isRequired,
+  timetableType: PropTypes.string.isRequired,
+  setTimetableType: PropTypes.func.isRequired,
+  term: PropTypes.string.isRequired,
+  setTerm: PropTypes.func.isRequired,
 };

--- a/src/components/generator/Forms/InputFormTopComponent.jsx
+++ b/src/components/generator/Forms/InputFormTopComponent.jsx
@@ -299,6 +299,7 @@ export default function InputFormTop({
         handleCourseCodeChange={handleCourseCodeChange}
         setCourseValue={handleSetCourseValue}
         addCourse={addCourse}
+        selectsDisabled={addedCourses.length > 0}
       />
       <SortOptions
         sortChoice={sortChoice}

--- a/src/components/generator/Forms/Settings/CourseOptions.jsx
+++ b/src/components/generator/Forms/Settings/CourseOptions.jsx
@@ -14,6 +14,7 @@ export default function CourseOptions({
   handleCourseCodeChange,
   setCourseValue,
   addCourse,
+  selectsDisabled,
 }) {
   return (
     <BorderBox title="Course Options">
@@ -21,8 +22,13 @@ export default function CourseOptions({
         <TimeTableSelectComponent
           timetable={timetableType}
           onTableChange={handleTableChange}
+          disabled={selectsDisabled}
         />
-        <TermSelectComponent term={term} onTermChange={handleTermChange} />
+        <TermSelectComponent
+          term={term}
+          onTermChange={handleTermChange}
+          disabled={selectsDisabled}
+        />
         <CourseSearchComponent
           onCourseCodeChange={handleCourseCodeChange}
           courseOptions={courseOptions}
@@ -45,4 +51,5 @@ CourseOptions.propTypes = {
   handleCourseCodeChange: PropTypes.func.isRequired,
   setCourseValue: PropTypes.func.isRequired,
   addCourse: PropTypes.func.isRequired,
+  selectsDisabled: PropTypes.bool,
 };

--- a/src/components/generator/Forms/Settings/CourseOptions.jsx
+++ b/src/components/generator/Forms/Settings/CourseOptions.jsx
@@ -6,6 +6,7 @@ import BorderBox from "../../UI/BorderBox";
 
 export default function CourseOptions({
   term,
+  timetableType,
   courseOptions,
   courseValue,
   handleTableChange,
@@ -17,7 +18,10 @@ export default function CourseOptions({
   return (
     <BorderBox title="Course Options">
       <div className="space-y-3">
-        <TimeTableSelectComponent onTableChange={handleTableChange} />
+        <TimeTableSelectComponent
+          timetable={timetableType}
+          onTableChange={handleTableChange}
+        />
         <TermSelectComponent term={term} onTermChange={handleTermChange} />
         <CourseSearchComponent
           onCourseCodeChange={handleCourseCodeChange}
@@ -33,6 +37,7 @@ export default function CourseOptions({
 
 CourseOptions.propTypes = {
   term: PropTypes.string.isRequired,
+  timetableType: PropTypes.string.isRequired,
   courseOptions: PropTypes.array.isRequired,
   courseValue: PropTypes.string.isRequired,
   handleTableChange: PropTypes.func.isRequired,

--- a/src/components/generator/Forms/Settings/ExportOptions.jsx
+++ b/src/components/generator/Forms/Settings/ExportOptions.jsx
@@ -33,7 +33,9 @@ export default function ExportOptions({ timetables, durations }) {
           <Collapsible open={showHelp} onOpenChange={setShowHelp}>
             <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
               <Info className="h-4 w-4" />
-              <span className="flex-1 text-left">How to use the .ics file (Export)</span>
+              <span className="flex-1 text-left">
+                How to use the .ics file (Export)
+              </span>
               {showHelp ? (
                 <ChevronUp className="h-4 w-4" />
               ) : (

--- a/src/components/generator/Forms/Settings/ExportOptions.jsx
+++ b/src/components/generator/Forms/Settings/ExportOptions.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import BorderBox from "../../UI/BorderBox";
 import ExportCalendarButton from "../../Export/ExportCalendarButton";
+import ShareTimetableButton from "../../Export/ShareTimetableButton";
 import { Info, ChevronDown, ChevronUp } from "lucide-react";
 import {
   Collapsible,
@@ -14,8 +15,13 @@ export default function ExportOptions({ timetables, durations }) {
   const [showHelp, setShowHelp] = useState(false);
 
   return (
-    <BorderBox title="Export Options">
+    <BorderBox title="Share & Save Options">
       <div className="flex flex-col gap-2">
+        {/* Share / save section — copies a link to this exact timetable */}
+        <div className="flex flex-col">
+          <ShareTimetableButton timetables={timetables} />
+        </div>
+
         {/* Main export section */}
         <div className="flex justify-center">
           <ExportCalendarButton timetables={timetables} durations={durations} />
@@ -27,7 +33,7 @@ export default function ExportOptions({ timetables, durations }) {
           <Collapsible open={showHelp} onOpenChange={setShowHelp}>
             <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
               <Info className="h-4 w-4" />
-              <span className="flex-1 text-left">How to use the .ics file</span>
+              <span className="flex-1 text-left">How to use the .ics file (Export)</span>
               {showHelp ? (
                 <ChevronUp className="h-4 w-4" />
               ) : (

--- a/src/components/generator/Forms/__tests__/GeneratorFeatureInteractions.test.jsx
+++ b/src/components/generator/Forms/__tests__/GeneratorFeatureInteractions.test.jsx
@@ -335,7 +335,7 @@ describe("generator feature interactions", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Export Calendar" }),
+      screen.getByRole("button", { name: "Export To Calendar App" }),
     );
 
     expect(mocks.exportCal).toHaveBeenCalledWith({ durationCount: 1 });

--- a/src/components/generator/Forms/__tests__/GeneratorFeatureInteractions.test.jsx
+++ b/src/components/generator/Forms/__tests__/GeneratorFeatureInteractions.test.jsx
@@ -211,6 +211,10 @@ describe("generator feature interactions", () => {
         setSortOption={setSortOption}
         addedCourses={[]}
         setAddedCourses={setAddedCourses}
+        timetableType="UG"
+        setTimetableType={vi.fn()}
+        term="FW"
+        setTerm={vi.fn()}
       />,
     );
 
@@ -268,6 +272,10 @@ describe("generator feature interactions", () => {
         setSortOption={setSortOption}
         addedCourses={[]}
         setAddedCourses={vi.fn()}
+        timetableType="UG"
+        setTimetableType={vi.fn()}
+        term="FW"
+        setTerm={vi.fn()}
       />,
     );
 

--- a/src/components/sitewide/MultiLineSnackbar.jsx
+++ b/src/components/sitewide/MultiLineSnackbar.jsx
@@ -1,10 +1,11 @@
 import { SnackbarContent } from "notistack";
 import PropTypes from "prop-types";
+import { cn } from "@/lib/utils";
 
-const MultiLineSnackbar = ({ message }) => {
+const MultiLineSnackbar = ({ message, className }) => {
   return (
     <SnackbarContent>
-      <div className="text-sm">
+      <div className={cn("text-sm", className)}>
         {message.split("\n").map((line, index) => (
           <span key={index}>
             {line}
@@ -20,4 +21,5 @@ export default MultiLineSnackbar;
 
 MultiLineSnackbar.propTypes = {
   message: PropTypes.string.isRequired,
+  className: PropTypes.string,
 };

--- a/src/components/sitewide/ShareFeatureBanner.jsx
+++ b/src/components/sitewide/ShareFeatureBanner.jsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { announcementBanner, BANNER_VARIANTS } from "@/lib/announcementBanner";
+
+// One-time announcement banner. All copy, the icon, the color, and the on/off
+// switch live in `@/lib/announcementBanner` — edit that file, not this one.
+// Starts hidden and only reveals after mount if the user hasn't dismissed this
+// version before, so returning visitors never see a flash.
+export default function ShareFeatureBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!announcementBanner.enabled) return;
+    if (!localStorage.getItem(announcementBanner.storageKey)) {
+      setVisible(true);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setVisible(false);
+    localStorage.setItem(announcementBanner.storageKey, "true");
+  };
+
+  if (!announcementBanner.enabled || !visible) {
+    return null;
+  }
+
+  const Icon = announcementBanner.icon;
+  const variant =
+    BANNER_VARIANTS[announcementBanner.variant] ?? BANNER_VARIANTS.primary;
+
+  return (
+    <div
+      className={cn(
+        "mx-2 mt-2 flex items-center gap-3 rounded-md border px-3 py-2 text-sm md:mx-1",
+        variant.container,
+      )}
+    >
+      {Icon && <Icon className={cn("h-4 w-4 shrink-0", variant.icon)} />}
+      <p className="flex-1 text-foreground">
+        {announcementBanner.title && (
+          <span className="font-semibold">{announcementBanner.title} </span>
+        )}
+        {announcementBanner.message}
+      </p>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Dismiss announcement"
+        className={cn(
+          "shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground",
+          variant.dismiss,
+        )}
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/announcementBanner.js
+++ b/src/lib/announcementBanner.js
@@ -1,0 +1,68 @@
+import { Share2 } from "lucide-react";
+
+/*
+Central config for the one-time announcement banner shown at the top of the
+generator page ([`ShareFeatureBanner.jsx`](src/components/sitewide/ShareFeatureBanner.jsx)).
+
+This is the ONLY file you need to edit for the banner:
+  - DISABLE it entirely .......... set `enabled: false`
+  - CHANGE THE TEXT .............. edit `title` / `message`
+  - CHANGE THE ICON ............. set `icon` to any lucide-react icon (or null)
+  - CHANGE THE COLOR ............ set `variant` to a key of BANNER_VARIANTS below
+                                   (or add/tweak a variant there)
+  - RE-SHOW it to everyone ....... bump `storageKey` (e.g. ".v1" -> ".v2");
+                                   each key is remembered separately, so a new
+                                   key makes the (updated) banner appear again
+                                   even for users who dismissed the old one.
+*/
+export const announcementBanner = {
+  enabled: true,
+
+  // Dismissal is remembered in localStorage under this key. Bump the version
+  // suffix whenever you want a changed message to re-appear for returning users.
+  storageKey: "announcementBanner.shareFeature.v1",
+
+  // Bold lead-in (e.g. "New:"). Leave as "" to omit.
+  title: "New:",
+
+  // Plain body text — apostrophes/ampersands are fine here (no HTML escaping).
+  message:
+    "You can now share & save your timetable. Once you've built your schedule, use the Share / Save Timetable button to copy a link you can revisit later or send to others.",
+
+  // Any lucide-react icon component, or null for no icon.
+  icon: Share2,
+
+  // Color scheme — must be a key of BANNER_VARIANTS below.
+  variant: "primary",
+};
+
+// Color schemes (Tailwind classes). Add your own or tweak these; they're scanned
+// by Tailwind because this file is under `src/`. `container` styles the box,
+// `icon` the leading icon, `dismiss` the close button's hover.
+export const BANNER_VARIANTS = {
+  primary: {
+    container: "border-primary/30 bg-primary/10",
+    icon: "text-primary",
+    dismiss: "hover:bg-primary/20",
+  },
+  info: {
+    container: "border-blue-500/30 bg-blue-500/10",
+    icon: "text-blue-500",
+    dismiss: "hover:bg-blue-500/20",
+  },
+  success: {
+    container: "border-green-600/30 bg-green-600/10",
+    icon: "text-green-600",
+    dismiss: "hover:bg-green-600/20",
+  },
+  warning: {
+    container: "border-amber-500/40 bg-amber-500/10",
+    icon: "text-amber-600",
+    dismiss: "hover:bg-amber-500/20",
+  },
+  neutral: {
+    container: "border-border bg-muted",
+    icon: "text-muted-foreground",
+    dismiss: "hover:bg-accent",
+  },
+};

--- a/src/lib/contexts/generator/CourseColorsContext.jsx
+++ b/src/lib/contexts/generator/CourseColorsContext.jsx
@@ -7,26 +7,7 @@ import {
   useMemo,
 } from "react";
 import PropTypes from "prop-types";
-
-// Visually distinguishable colors that work well for both light and dark themes
-// Colors are ordered to maximize contrast between consecutive colors
-const defaultColors = [
-  "#E74C3C", // Bright Red
-  "#3498DB", // Bright Blue
-  "#F1C40F", // Bright Yellow
-  "#9B59B6", // Purple
-  "#2ECC71", // Bright Green
-  "#E67E22", // Orange
-  "#34495E", // Navy Blue
-  "#FF6B6B", // Coral Red
-  "#1ABC9C", // Emerald
-  "#8E44AD", // Deep Purple
-  "#D35400", // Burnt Orange
-  "#16A085", // Dark Teal
-  "#C0392B", // Dark Red
-  "#2980B9", // Dark Blue
-  "#27AE60", // Dark Green
-];
+import { defaultColors } from "./courseColorPalette";
 
 export const CourseColorsContext = createContext();
 
@@ -91,6 +72,14 @@ export const CourseColorsProvider = ({ children }) => {
     [updateCalendarColors],
   );
 
+  // Bulk-apply a saved { courseCode: hex } map (used when restoring a shared URL).
+  // Bypasses updateCourseColor's debounce so every color lands in one pass.
+  const restoreCourseColors = useCallback((colorMap) => {
+    const map = colorMap || {};
+    setCourseColors(map);
+    setUsedColors(Object.values(map));
+  }, []);
+
   const getDefaultColorForCourse = useCallback(
     (courseCode) => {
       if (courseColors[courseCode]) {
@@ -132,6 +121,7 @@ export const CourseColorsProvider = ({ children }) => {
       updateCourseColor,
       getDefaultColorForCourse,
       initializeCourseColor,
+      restoreCourseColors,
       setCalendarUpdateHandler,
     }),
     [
@@ -139,6 +129,7 @@ export const CourseColorsProvider = ({ children }) => {
       updateCourseColor,
       getDefaultColorForCourse,
       initializeCourseColor,
+      restoreCourseColors,
       setCalendarUpdateHandler,
     ],
   );

--- a/src/lib/contexts/generator/courseColorPalette.js
+++ b/src/lib/contexts/generator/courseColorPalette.js
@@ -1,0 +1,27 @@
+// Single source of truth for the auto-assigned course colors. Courses are given
+// palette[i] in the order they are added, so the URL codec can re-derive default
+// colors on restore and only persist user-customized overrides.
+//
+// Visually distinguishable colors that work well for both light and dark themes,
+// ordered to maximize contrast between consecutive entries.
+export const defaultColors = [
+  "#E74C3C", // Bright Red
+  "#3498DB", // Bright Blue
+  "#F1C40F", // Bright Yellow
+  "#9B59B6", // Purple
+  "#2ECC71", // Bright Green
+  "#E67E22", // Orange
+  "#34495E", // Navy Blue
+  "#FF6B6B", // Coral Red
+  "#1ABC9C", // Emerald
+  "#8E44AD", // Deep Purple
+  "#D35400", // Burnt Orange
+  "#16A085", // Dark Teal
+  "#C0392B", // Dark Red
+  "#2980B9", // Dark Blue
+  "#27AE60", // Dark Green
+];
+
+// The default color a course at position `index` (0-based, in add order) receives.
+export const defaultColorForIndex = (index) =>
+  defaultColors[index % defaultColors.length];

--- a/src/lib/generator/createCalendarEvents.js
+++ b/src/lib/generator/createCalendarEvents.js
@@ -300,6 +300,10 @@ export const removeTimeBlockEvent = (blockId) => {
   timeBlockEvents = timeBlockEvents.filter((block) => block.id !== blockId);
 };
 
+export const clearAllTimeBlockEvents = () => {
+  timeBlockEvents = [];
+};
+
 export const updateTimeBlockEventTitle = (blockId, newTitle) => {
   const blockIndex = timeBlockEvents.findIndex((block) => block.id === blockId);
   if (blockIndex !== -1) {

--- a/src/lib/generator/timeSlots.js
+++ b/src/lib/generator/timeSlots.js
@@ -37,4 +37,9 @@ export const setOpenTimeSlots = (blockedSlots) => {
   updateSlots(blockedSlots, false);
 };
 
+export const reinitializeTimeSlots = () => {
+  timeSlots = {};
+  initializeTimeSlots();
+};
+
 initializeTimeSlots();

--- a/src/lib/urlState/__tests__/urlEncoder.test.js
+++ b/src/lib/urlState/__tests__/urlEncoder.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { encodeState, decodeState } from "../urlEncoder";
+
+describe("urlEncoder round-trip", () => {
+  it("round-trips a full state object", () => {
+    const state = {
+      v: 2,
+      tt: "UG",
+      term: "FW",
+      c: ["COSC 1P02 D2", "MATH 1P01 D1"],
+      p: ["3591102", "3591103"],
+      sort: "w",
+      tb: [
+        { d: "M", s: "09:00", e: "11:00", n: "Work" },
+        { d: "W", s: "14:00", e: "16:00", n: "Gym" },
+      ],
+      sd: "2",
+      col: { COSC1P02: "#E74C3C", MATH1P01: "#3498DB" },
+    };
+
+    const decoded = decodeState(encodeState(state));
+    expect(decoded).toEqual(state);
+  });
+
+  it("round-trips the selected duration code and color overrides", () => {
+    const state = {
+      v: 2,
+      tt: "UG",
+      term: "FW",
+      c: ["COSC 1P02 D2"],
+      p: ["3591102"],
+      tb: [],
+      sd: "2",
+      col: { COSC1P02: "#9B59B6" },
+    };
+    expect(decodeState(encodeState(state))).toEqual(state);
+  });
+
+  it("omits sd and col when absent", () => {
+    const state = {
+      v: 2,
+      tt: "UG",
+      term: "FW",
+      c: ["COSC 1P02 D2"],
+      p: ["3591102"],
+      tb: [],
+    };
+    const decoded = decodeState(encodeState(state));
+    expect(decoded.sd).toBeUndefined();
+    expect(decoded.col).toBeUndefined();
+    expect(decoded).toEqual(state);
+  });
+
+  it("omits sort for the default sort option", () => {
+    const state = {
+      v: 2,
+      tt: "GR",
+      term: "SP",
+      c: ["PSYC 1F90 D1"],
+      p: ["1234567"],
+      tb: [],
+    };
+
+    const decoded = decodeState(encodeState(state));
+    expect(decoded.sort).toBeUndefined();
+    expect(decoded).toEqual(state);
+  });
+
+  it("sorts pins and round-trips many clustered section IDs", () => {
+    const state = {
+      v: 2,
+      tt: "UG",
+      term: "FW",
+      c: ["COSC 1P02 D2"],
+      // intentionally unsorted; decode returns them sorted ascending
+      p: ["3591140", "3591102", "3591103", "3591142"],
+      tb: [],
+    };
+    const decoded = decodeState(encodeState(state));
+    expect(decoded.p).toEqual(["3591102", "3591103", "3591140", "3591142"]);
+  });
+
+  it("escapes unknown tt/term values", () => {
+    const state = {
+      v: 2,
+      tt: "ZZ",
+      term: "QQ",
+      c: ["COSC 1P02 D2"],
+      p: ["3591102"],
+      tb: [],
+    };
+    const decoded = decodeState(encodeState(state));
+    expect(decoded.tt).toBe("ZZ");
+    expect(decoded.term).toBe("QQ");
+  });
+
+  it("handles empty pins and blocks", () => {
+    const state = {
+      v: 2,
+      tt: "UG",
+      term: "FW",
+      c: ["COSC 1P02 D2"],
+      p: [],
+      tb: [],
+    };
+    expect(decodeState(encodeState(state))).toEqual(state);
+  });
+
+  it("preserves a blank time-block name", () => {
+    const state = {
+      v: 2,
+      tt: "UG",
+      term: "FW",
+      c: ["COSC 1P02 D2"],
+      p: ["3591102"],
+      tb: [{ d: "F", s: "08:00", e: "08:30", n: "" }],
+    };
+    expect(decodeState(encodeState(state))).toEqual(state);
+  });
+
+  it("returns null on corrupt input", () => {
+    expect(decodeState("not-valid-base64url!!!")).toBeNull();
+    expect(decodeState("")).toBeNull();
+  });
+
+  it("produces a URL-safe string with no padding", () => {
+    const encoded = encodeState({
+      v: 2,
+      tt: "UG",
+      term: "FW",
+      c: ["COSC 1P02 D2"],
+      p: ["3591102"],
+      tb: [],
+    });
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+});

--- a/src/lib/urlState/urlEncoder.js
+++ b/src/lib/urlState/urlEncoder.js
@@ -124,7 +124,9 @@ const writeBinary = (state) => {
   bytes.push(0x00);
 
   // pins: count, then sorted IDs as varint deltas (first is an absolute varint).
-  const pins = (state.p || []).map((id) => Number(id) >>> 0).sort((a, b) => a - b);
+  const pins = (state.p || [])
+    .map((id) => Number(id) >>> 0)
+    .sort((a, b) => a - b);
   bytes.push(pins.length & 0xff);
   let prev = 0;
   pins.forEach((id) => {
@@ -220,9 +222,7 @@ const readBinary = (bytes) => {
   while (offset < bytes.length && bytes[offset] !== 0x00) offset += 1;
   const courseString = textDecoder.decode(bytes.subarray(courseStart, offset));
   offset += 1; // skip terminator
-  const c = courseString
-    ? courseString.split(",").map(restoreCourseLabel)
-    : [];
+  const c = courseString ? courseString.split(",").map(restoreCourseLabel) : [];
 
   // pins (varint deltas of sorted IDs)
   const pinCount = readByte();
@@ -275,10 +275,7 @@ const bytesToBase64Url = (bytes) => {
   for (let i = 0; i < bytes.length; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
-  return btoa(binary)
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=/g, "");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 };
 
 const base64UrlToBytes = (str) => {

--- a/src/lib/urlState/urlEncoder.js
+++ b/src/lib/urlState/urlEncoder.js
@@ -1,0 +1,309 @@
+import { deflateSync, inflateSync } from "fflate";
+
+/*
+URL state codec (format v2).
+
+Pipeline:
+  state object -> binary pack -> deflate (fflate) -> base64url -> ?s=<string>
+
+The binary layout is documented inline in writeBinary/readBinary below and must
+be kept byte-for-byte in sync between the two. The whole decode path is wrapped
+in try/catch so any corruption simply yields null (caller treats that as a
+"shared timetable no longer exists" error).
+
+The format is tuned for short URLs:
+  - tt/term are 1-byte enum indices (with a 0xFF escape for unknown values).
+  - pin section IDs are sorted, then stored as varints of the deltas, so the
+    clustered IDs of a single term pack into ~1 byte each.
+  - sd holds only the selected duration *code* ("2"); the date range is rebuilt
+    from course data on restore.
+  - col holds only user-customized colors; defaults are re-derived from order.
+*/
+
+const SCHEMA_VERSION = 2;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+// 1-byte enum tables; 0xFF marks an escape to a length-prefixed string.
+const ESCAPE = 0xff;
+const TT_TABLE = ["UG", "AD", "PS", "GR"];
+const TERM_TABLE = ["FW", "SP", "SU"];
+
+// state.sort ("w"/"d"/undefined) <-> binary sort byte (0/1/2)
+const SORT_KEY_TO_BYTE = { w: 1, d: 2 };
+const SORT_BYTE_TO_KEY = { 1: "w", 2: "d" };
+
+// Day letter <-> byte
+const DAY_TO_BYTE = { M: 0, T: 1, W: 2, R: 3, F: 4, S: 5, U: 6 };
+const BYTE_TO_DAY = ["M", "T", "W", "R", "F", "S", "U"];
+
+// "09:00" -> slot index (8AM == slot 0, 30-min granularity)
+const timeToSlot = (time) => {
+  const [h, m] = time.split(":").map(Number);
+  return (h - 8) * 2 + m / 30;
+};
+
+// slot index -> "HH:MM"
+const slotToTime = (slot) => {
+  const hour = Math.floor(slot / 2) + 8;
+  const minute = slot % 2 === 0 ? "00" : "30";
+  return `${String(hour).padStart(2, "0")}:${minute}`;
+};
+
+// Course labels round-trip through a space-stripped, comma-joined string. The
+// Brock code format is fixed (AAAA 9A99 D9+) so spaces can be re-inserted
+// deterministically on decode.
+const stripCourseLabel = (label) => label.replace(/\s+/g, "");
+const restoreCourseLabel = (compact) =>
+  `${compact.slice(0, 4)} ${compact.slice(4, 8)} ${compact.slice(8)}`;
+
+// "COSC 1P02 D2" -> "COSC1P02" (the space-less course code colors are keyed on).
+const courseLabelToCode = (label) => {
+  const parts = label.trim().split(/\s+/);
+  return `${parts[0] ?? ""}${parts[1] ?? ""}`;
+};
+
+const hexToRgb = (hex) => {
+  const clean = hex.replace("#", "");
+  return [
+    parseInt(clean.slice(0, 2), 16) || 0,
+    parseInt(clean.slice(2, 4), 16) || 0,
+    parseInt(clean.slice(4, 6), 16) || 0,
+  ];
+};
+
+// Uppercase to match the default color palette in CourseColorsContext, so the
+// "used colors" dedup recognizes restored colors when assigning new ones.
+const rgbToHex = (r, g, b) => {
+  const hex = [r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("");
+  return `#${hex.toUpperCase()}`;
+};
+
+const writeBinary = (state) => {
+  const bytes = [];
+
+  const pushBytes = (source) => {
+    for (let i = 0; i < source.length; i++) bytes.push(source[i]);
+  };
+  const pushLengthPrefixedString = (str) => {
+    const encoded = textEncoder.encode(str);
+    bytes.push(encoded.length & 0xff);
+    pushBytes(encoded);
+  };
+  // Enum index byte, or 0xFF escape followed by a length-prefixed string.
+  const pushEnum = (value, table) => {
+    const index = table.indexOf(value);
+    if (index >= 0) {
+      bytes.push(index);
+    } else {
+      bytes.push(ESCAPE);
+      pushLengthPrefixedString(value || "");
+    }
+  };
+  // Unsigned LEB128 varint.
+  const pushVarint = (value) => {
+    let n = value >>> 0;
+    while (n > 0x7f) {
+      bytes.push((n & 0x7f) | 0x80);
+      n >>>= 7;
+    }
+    bytes.push(n & 0x7f);
+  };
+
+  // [1 byte] version
+  bytes.push(SCHEMA_VERSION);
+
+  // tt + term enums
+  pushEnum(state.tt || "UG", TT_TABLE);
+  pushEnum(state.term || "FW", TERM_TABLE);
+
+  // course string (labels space-stripped, comma-joined) + 0x00 terminator
+  const courseString = (state.c || []).map(stripCourseLabel).join(",");
+  pushBytes(textEncoder.encode(courseString));
+  bytes.push(0x00);
+
+  // pins: count, then sorted IDs as varint deltas (first is an absolute varint).
+  const pins = (state.p || []).map((id) => Number(id) >>> 0).sort((a, b) => a - b);
+  bytes.push(pins.length & 0xff);
+  let prev = 0;
+  pins.forEach((id) => {
+    pushVarint(id - prev);
+    prev = id;
+  });
+
+  // [1 byte] sort byte
+  bytes.push(SORT_KEY_TO_BYTE[state.sort] ?? 0);
+
+  // [1 byte] time block count, then 4+ bytes per block
+  const tb = state.tb || [];
+  bytes.push(tb.length & 0xff);
+  tb.forEach((block) => {
+    bytes.push(DAY_TO_BYTE[block.d] ?? 0);
+    bytes.push(timeToSlot(block.s) & 0xff);
+    bytes.push(timeToSlot(block.e) & 0xff);
+    pushLengthPrefixedString(block.n || "");
+  });
+
+  // selected duration code ("2"), "" when none
+  pushLengthPrefixedString(state.sd || "");
+
+  // color overrides: count, then [course index, R, G, B] per entry. Only colors
+  // that differ from the default palette assignment are stored here.
+  const courseCodes = (state.c || []).map(courseLabelToCode);
+  const colorEntries = Object.entries(state.col || {}).filter(([code]) =>
+    courseCodes.includes(code),
+  );
+  bytes.push(colorEntries.length & 0xff);
+  colorEntries.forEach(([code, hex]) => {
+    bytes.push(courseCodes.indexOf(code) & 0xff);
+    const [r, g, b] = hexToRgb(hex);
+    bytes.push(r & 0xff);
+    bytes.push(g & 0xff);
+    bytes.push(b & 0xff);
+  });
+
+  return new Uint8Array(bytes);
+};
+
+const readBinary = (bytes) => {
+  let offset = 0;
+
+  const readByte = () => {
+    if (offset >= bytes.length) throw new Error("Unexpected end of buffer");
+    const value = bytes[offset];
+    offset += 1;
+    return value;
+  };
+
+  const readBytes = (length) => {
+    if (offset + length > bytes.length) {
+      throw new Error("Unexpected end of buffer");
+    }
+    const slice = bytes.subarray(offset, offset + length);
+    offset += length;
+    return slice;
+  };
+
+  const readLengthPrefixedString = () => {
+    const len = readByte();
+    return textDecoder.decode(readBytes(len));
+  };
+
+  const readEnum = (table, fallback) => {
+    const b = readByte();
+    if (b === ESCAPE) return readLengthPrefixedString() || fallback;
+    return table[b] ?? fallback;
+  };
+
+  const readVarint = () => {
+    let result = 0;
+    let shift = 0;
+    let byte;
+    do {
+      byte = readByte();
+      result |= (byte & 0x7f) << shift;
+      shift += 7;
+    } while (byte & 0x80);
+    return result >>> 0;
+  };
+
+  // version (read for completeness; only v2 is produced)
+  readByte();
+
+  // tt + term
+  const tt = readEnum(TT_TABLE, "UG");
+  const term = readEnum(TERM_TABLE, "FW");
+
+  // course string up to 0x00 terminator
+  const courseStart = offset;
+  while (offset < bytes.length && bytes[offset] !== 0x00) offset += 1;
+  const courseString = textDecoder.decode(bytes.subarray(courseStart, offset));
+  offset += 1; // skip terminator
+  const c = courseString
+    ? courseString.split(",").map(restoreCourseLabel)
+    : [];
+
+  // pins (varint deltas of sorted IDs)
+  const pinCount = readByte();
+  const p = [];
+  let prev = 0;
+  for (let i = 0; i < pinCount; i++) {
+    prev += readVarint();
+    p.push(String(prev >>> 0));
+  }
+
+  // sort
+  const sortByte = readByte();
+  const sort = SORT_BYTE_TO_KEY[sortByte];
+
+  // time blocks
+  const tbCount = readByte();
+  const tb = [];
+  for (let i = 0; i < tbCount; i++) {
+    const d = BYTE_TO_DAY[readByte()] ?? "M";
+    const s = slotToTime(readByte());
+    const e = slotToTime(readByte());
+    const n = readLengthPrefixedString();
+    tb.push({ d, s, e, n });
+  }
+
+  // selected duration code
+  const sd = readLengthPrefixedString();
+
+  // color overrides
+  const col = {};
+  const colorCount = readByte();
+  for (let i = 0; i < colorCount; i++) {
+    const index = readByte();
+    const r = readByte();
+    const g = readByte();
+    const b = readByte();
+    const label = c[index];
+    if (label) col[courseLabelToCode(label)] = rgbToHex(r, g, b);
+  }
+
+  const state = { v: SCHEMA_VERSION, tt, term, c, p, tb };
+  if (sort) state.sort = sort;
+  if (sd) state.sd = sd;
+  if (Object.keys(col).length) state.col = col;
+  return state;
+};
+
+const bytesToBase64Url = (bytes) => {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+};
+
+const base64UrlToBytes = (str) => {
+  let normalized = str.replace(/-/g, "+").replace(/_/g, "/");
+  while (normalized.length % 4 !== 0) normalized += "=";
+  const binary = atob(normalized);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+};
+
+export const encodeState = (stateObj) => {
+  const packed = writeBinary(stateObj);
+  const compressed = deflateSync(packed);
+  return bytesToBase64Url(compressed);
+};
+
+export const decodeState = (str) => {
+  try {
+    const compressed = base64UrlToBytes(str);
+    const packed = inflateSync(compressed);
+    return readBinary(packed);
+  } catch {
+    return null;
+  }
+};

--- a/src/lib/urlState/urlStateUtils.js
+++ b/src/lib/urlState/urlStateUtils.js
@@ -117,7 +117,10 @@ export function syncUrlToState({
   addedCourses.forEach((label, i) => {
     const code = label.trim().split(/\s+/).slice(0, 2).join("");
     const actual = (courseColors || {})[code];
-    if (actual && actual.toUpperCase() !== defaultColorForIndex(i).toUpperCase()) {
+    if (
+      actual &&
+      actual.toUpperCase() !== defaultColorForIndex(i).toUpperCase()
+    ) {
       colorOverrides[code] = actual;
     }
   });

--- a/src/lib/urlState/urlStateUtils.js
+++ b/src/lib/urlState/urlStateUtils.js
@@ -1,0 +1,149 @@
+import { encodeState } from "./urlEncoder";
+import { defaultColorForIndex } from "@/lib/contexts/generator/courseColorPalette";
+
+/*
+Helpers that bridge the live generator state (singletons + React) and the URL
+codec. The URL always encodes a "fully pinned" snapshot of the currently
+displayed timetable so that every shared link is deterministic.
+*/
+
+// Section IDs that uniquely identify the currently displayed timetable. The
+// -1/-2 suffixes that exist only for FullCalendar event uniqueness are stripped,
+// and a Set dedupes the shared base id of multi-main sections.
+export function extractCurrentTimetablePinIds(timetable) {
+  if (!timetable?.courses) return [];
+  const ids = new Set();
+  timetable.courses.forEach((course) => {
+    course.mainComponents?.forEach((c) => {
+      const baseId = c.id.includes("-") ? c.id.split("-")[0] : c.id;
+      ids.add(baseId);
+    });
+    const sec = course.secondaryComponents;
+    if (sec?.lab) ids.add(sec.lab.id);
+    if (sec?.tutorial) ids.add(sec.tutorial.id);
+    if (sec?.seminar) ids.add(sec.seminar.id);
+  });
+  return [...ids];
+}
+
+// Reconstruct full pin strings ("COSC1P02 MAIN 3591102") from bare section IDs
+// by looking each one up in the already-fetched course data. allFound is false
+// if any ID is missing (course no longer offers that section).
+export function buildPinStringsFromIds(sectionIds, courseData) {
+  const idMap = {};
+  Object.values(courseData).forEach((course) => {
+    const cc = course.courseCode;
+    course.sections?.forEach((s) => {
+      idMap[s.id] = { courseCode: cc, type: "MAIN" };
+    });
+    course.labs?.forEach((s) => {
+      idMap[s.id] = { courseCode: cc, type: "LAB" };
+    });
+    course.tutorials?.forEach((s) => {
+      idMap[s.id] = { courseCode: cc, type: "TUT" };
+    });
+    course.seminars?.forEach((s) => {
+      idMap[s.id] = { courseCode: cc, type: "SEM" };
+    });
+  });
+
+  const pinStrings = [];
+  let allFound = true;
+  sectionIds.forEach((id) => {
+    if (idMap[id]) {
+      const { courseCode, type } = idMap[id];
+      pinStrings.push(`${courseCode} ${type} ${id}`);
+    } else {
+      allFound = false;
+    }
+  });
+  return { pinStrings, allFound };
+}
+
+// "COSC 1P02 D2" -> { cleanCourseCode: "COSC1P02", duration: "2" }
+export function parseCourseLabel(label) {
+  const parts = label.trim().split(" ");
+  return {
+    cleanCourseCode: parts[0] + parts[1],
+    duration: parts[2].substring(1),
+  };
+}
+
+// Builds the "<startUnix>-<endUnix>-<code>" duration label for a freshly fetched
+// course, matching how InputFormTopComponent derives it on a normal add. Returns
+// null if the course has no section for that duration code.
+export function buildDurationLabel(courseData, durationCode) {
+  for (const key in courseData.sections) {
+    const section = courseData.sections[key];
+    if (section.schedule.duration === durationCode) {
+      return `${section.schedule.startDate}-${section.schedule.endDate}-${durationCode}`;
+    }
+  }
+  return null;
+}
+
+// Encode the current state and silently replace the URL. Clears ?s= when there
+// are no courses. Uses history.replaceState (never pushState) so the back button
+// never walks through timetable states.
+export function syncUrlToState({
+  currentTimetable,
+  addedCourses,
+  sortOption,
+  timetableType,
+  term,
+  timeBlockEvents,
+  selectedDuration,
+  courseColors,
+}) {
+  const url = new URL(window.location.href);
+
+  if (!addedCourses.length) {
+    url.searchParams.delete("s");
+    history.replaceState(null, "", url);
+    return;
+  }
+
+  const sortMap = { sortByWaitingTime: "w", minimizeClassDays: "d" };
+
+  // Only the duration *code* is stored; the date range is rebuilt from course
+  // data on restore. "1725321600-1732924800-2" -> "2".
+  const durationCode = selectedDuration
+    ? selectedDuration.split("-")[2] || ""
+    : "";
+
+  // Only persist colors the user actually changed: default palette colors are
+  // re-derived from course order on restore, so they cost nothing here.
+  const colorOverrides = {};
+  addedCourses.forEach((label, i) => {
+    const code = label.trim().split(/\s+/).slice(0, 2).join("");
+    const actual = (courseColors || {})[code];
+    if (actual && actual.toUpperCase() !== defaultColorForIndex(i).toUpperCase()) {
+      colorOverrides[code] = actual;
+    }
+  });
+
+  const state = {
+    v: 2,
+    tt: timetableType,
+    term,
+    c: addedCourses,
+    p: extractCurrentTimetablePinIds(currentTimetable),
+    sort: sortMap[sortOption],
+    tb: timeBlockEvents.map((b) => ({
+      d: b.daysOfWeek.trim(),
+      s: b.startTime,
+      e: b.endTime,
+      n: b.title || "",
+    })),
+    sd: durationCode,
+    col: colorOverrides,
+  };
+
+  try {
+    url.searchParams.set("s", encodeState(state));
+    history.replaceState(null, "", url);
+  } catch (e) {
+    // Non-fatal — URL just won't update.
+    console.warn("URL state sync failed", e);
+  }
+}

--- a/src/pages/GeneratorPage.jsx
+++ b/src/pages/GeneratorPage.jsx
@@ -54,6 +54,7 @@ import {
 } from "@/lib/urlState/urlStateUtils";
 import eventBus from "@/lib/eventBus";
 import FooterComponent from "@/components/sitewide/FooterComponent";
+import ShareFeatureBanner from "@/components/sitewide/ShareFeatureBanner";
 import { usePageMeta } from "@/lib/usePageMeta";
 
 const conflictSignature = (info) =>
@@ -388,6 +389,7 @@ function GeneratorPageContent() {
     <div className="flex min-w-[350px] flex-col items-center">
       <div className="w-full max-w-[1280px]">
         <NavbarComponent />
+        <ShareFeatureBanner />
         <div className="grid grid-cols-1 justify-center md:grid-cols-12">
           <div className="md:col-span-4">
             <div className="mx-2 mt-2 md:mx-1">

--- a/src/pages/GeneratorPage.jsx
+++ b/src/pages/GeneratorPage.jsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback, useContext } from "react";
+import { useSnackbar } from "notistack";
 import {
   NavbarComponent,
   CalendarComponent,
@@ -7,16 +8,35 @@ import {
 } from "@/components/generator";
 import { useIsBelowMedium } from "@/lib/utils/screenSizeUtils";
 import { CourseDetailsProvider } from "@/lib/contexts/generator/CourseDetailsContext";
-import { CourseColorsProvider } from "@/lib/contexts/generator/CourseColorsContext";
+import {
+  CourseColorsProvider,
+  CourseColorsContext,
+} from "@/lib/contexts/generator/CourseColorsContext";
+import { defaultColorForIndex } from "@/lib/contexts/generator/courseColorPalette";
 import IntroGuideWidget from "@/components/generator/Dialogs/IntroGuideWidget";
 import ConflictDialog from "@/components/generator/Dialogs/ConflictDialog";
+import MultiLineSnackbar from "@/components/sitewide/MultiLineSnackbar";
 import { trackPageView } from "@/lib/metrics";
-import { clearAllCourseData } from "@/lib/generator/courseData";
+import {
+  storeCourseData,
+  getCourseData,
+  clearAllCourseData,
+} from "@/lib/generator/courseData";
 import {
   clearAllPins,
   addPinnedComponent,
   getPinnedComponents,
 } from "@/lib/generator/pinnedComponents";
+import {
+  addTimeBlockEvent,
+  getTimeBlockEvents,
+  clearAllTimeBlockEvents,
+} from "@/lib/generator/createCalendarEvents";
+import {
+  setBlockedTimeSlots,
+  reinitializeTimeSlots,
+} from "@/lib/generator/timeSlots";
+import { getCourse } from "@/lib/generator/fetchData";
 import {
   generateTimetables,
   getValidTimetables,
@@ -25,6 +45,13 @@ import {
   removeAddedCourse,
   findCourseLabelByCode,
 } from "@/lib/generator/courseActions";
+import { decodeState } from "@/lib/urlState/urlEncoder";
+import {
+  syncUrlToState,
+  parseCourseLabel,
+  buildPinStringsFromIds,
+  buildDurationLabel,
+} from "@/lib/urlState/urlStateUtils";
 import eventBus from "@/lib/eventBus";
 import FooterComponent from "@/components/sitewide/FooterComponent";
 import { usePageMeta } from "@/lib/usePageMeta";
@@ -50,7 +77,7 @@ const isConflictAcknowledged = (acknowledged, info) => {
   return acknowledged.pinTargets.every((pin) => pinned.includes(pin));
 };
 
-function GeneratorPage() {
+function GeneratorPageContent() {
   usePageMeta({
     title: "Brock Visual TimeTable",
     description:
@@ -64,16 +91,42 @@ function GeneratorPage() {
       title: "Brock Visual TimeTable",
     });
   }, []);
+  const { enqueueSnackbar } = useSnackbar();
+  const { courseColors, restoreCourseColors } =
+    useContext(CourseColorsContext);
   const [timetables, setTimetables] = useState([]);
   const [selectedDuration, setSelectedDuration] = useState("");
   const [durations, setDurations] = useState([]);
   const [sortOption, setSortOption] = useState("");
   const [addedCourses, setAddedCourses] = useState([]);
+  const [currentTimetableIndex, setCurrentTimetableIndex] = useState(0);
+  const [timetableType, setTimetableType] = useState("UG");
+  const [term, setTerm] = useState("FW");
+  const [timeBlockVersion, setTimeBlockVersion] = useState(0);
   const [conflictInfo, setConflictInfo] = useState(null);
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
   const conflictInfoRef = useRef(null);
   const acknowledgedRef = useRef(null);
   const isBelowMedium = useIsBelowMedium();
+
+  // Capture the shared-state param synchronously at first render. The URL sync
+  // effect runs before the restore effect on mount and (with no courses yet)
+  // strips ?s=, so we must read it before that happens.
+  const initialEncodedRef = useRef(undefined);
+  if (initialEncodedRef.current === undefined) {
+    initialEncodedRef.current = new URLSearchParams(
+      window.location.search,
+    ).get("s");
+  }
+
+  // timeBlockEvents is a singleton, so mutations don't trigger React effects.
+  // Bumping this version lets the URL sync effect observe time block changes.
+  const onTimeBlockChange = useCallback(
+    () => setTimeBlockVersion((v) => v + 1),
+    [],
+  );
+
+  const currentTimetable = timetables[currentTimetableIndex] ?? null;
 
   useEffect(() => {
     conflictInfoRef.current = conflictInfo;
@@ -157,74 +210,264 @@ function GeneratorPage() {
     };
   }, []);
 
+  // Keep the URL in sync with the currently displayed timetable. The URL always
+  // encodes a fully pinned snapshot, so every shared link is deterministic.
+  useEffect(() => {
+    syncUrlToState({
+      currentTimetable,
+      addedCourses,
+      sortOption,
+      timetableType,
+      term,
+      timeBlockEvents: getTimeBlockEvents(),
+      selectedDuration,
+      courseColors,
+    });
+  }, [
+    currentTimetable,
+    addedCourses,
+    sortOption,
+    timetableType,
+    term,
+    timeBlockVersion,
+    selectedDuration,
+    courseColors,
+  ]);
+
+  const showError = useCallback(() => {
+    enqueueSnackbar(
+      <MultiLineSnackbar message="Error: The shared timetable does not exist or is no longer being offered." />,
+      { variant: "error" },
+    );
+  }, [enqueueSnackbar]);
+
+  // Restoration is all-or-nothing: any failure wipes everything back to a blank
+  // slate, drops the ?s= param, and shows the single error snackbar.
+  const resetToBlankSlate = useCallback(() => {
+    clearAllCourseData();
+    clearAllPins();
+    clearAllTimeBlockEvents();
+    reinitializeTimeSlots();
+    restoreCourseColors({});
+    setAddedCourses([]);
+    setTimetables([]);
+    setSortOption("");
+    setTimetableType("UG");
+    setTerm("FW");
+    setSelectedDuration("");
+    setDurations([]);
+    const url = new URL(window.location.href);
+    url.searchParams.delete("s");
+    history.replaceState(null, "", url);
+  }, [restoreCourseColors]);
+
+  const restoreFromUrlState = useCallback(
+    async (encoded) => {
+      // Step 1: Decode
+      const state = decodeState(encoded);
+      if (!state) {
+        showError();
+        return;
+      }
+
+      // Step 2: Restore term and timetableType
+      setTimetableType(state.tt);
+      setTerm(state.term);
+
+      // Step 3: Restore time blocks (singleton events + blocked slot grid)
+      for (const [i, block] of state.tb.entries()) {
+        const blockObj = {
+          id: `restore-${Date.now()}-${i}-${block.d}`,
+          title: block.n || "",
+          daysOfWeek: block.d,
+          startTime: block.s,
+          endTime: block.e,
+          startRecur: "1970-01-01",
+          endRecur: "9999-12-31",
+        };
+        addTimeBlockEvent(blockObj);
+
+        const [sh, sm] = block.s.split(":").map(Number);
+        const [eh, em] = block.e.split(":").map(Number);
+        const slotStart = (sh - 8) * 2 + sm / 30;
+        const slotEnd = (eh - 8) * 2 + em / 30;
+        const slots = [];
+        for (let s = slotStart; s < slotEnd; s++) slots.push(s);
+        setBlockedTimeSlots({ [block.d]: slots });
+      }
+
+      // Step 4: Load all courses sequentially (mirrors a normal add, including
+      // the DURATION pin that scopes generation to the right academic duration).
+      // Collect each course's duration label so the timeline options can be
+      // rebuilt — restore bypasses InputFormTopComponent, which normally does it.
+      const restoredDurations = [];
+      try {
+        for (const courseLabel of state.c) {
+          const { cleanCourseCode, duration } = parseCourseLabel(courseLabel);
+          const courseData = await getCourse(
+            cleanCourseCode,
+            state.tt,
+            state.term,
+          );
+          storeCourseData(courseData);
+          setAddedCourses((prev) => [...prev, courseLabel]);
+          addPinnedComponent(`${cleanCourseCode} DURATION ${duration}`);
+
+          const durationLabel = buildDurationLabel(courseData, duration);
+          if (durationLabel && !restoredDurations.includes(durationLabel)) {
+            restoredDurations.push(durationLabel);
+          }
+        }
+      } catch (e) {
+        resetToBlankSlate();
+        showError();
+        return;
+      }
+
+      // Step 5: Apply section pins, verifying every ID exists in fetched data.
+      const { pinStrings, allFound } = buildPinStringsFromIds(
+        state.p,
+        getCourseData(),
+      );
+      if (!allFound) {
+        resetToBlankSlate();
+        showError();
+        return;
+      }
+      pinStrings.forEach((pin) => addPinnedComponent(pin));
+
+      // Step 6: Generate
+      const sortMap = { w: "sortByWaitingTime", d: "minimizeClassDays" };
+      const sort = sortMap[state.sort] ?? "default";
+      setSortOption(sort);
+      generateTimetables(sort);
+      const result = getValidTimetables();
+
+      // Step 7: Verify generation produced a real timetable.
+      if (
+        !result.length ||
+        (result.length === 1 && !result[0].courses?.length)
+      ) {
+        resetToBlankSlate();
+        showError();
+        return;
+      }
+
+      // Step 8: Restore the duration timeline options, the duration view the
+      // user was on (matched by code), and the per-course colors.
+      setDurations(restoredDurations);
+      const savedDuration =
+        restoredDurations.find((d) => d.split("-")[2] === state.sd) ??
+        restoredDurations[restoredDurations.length - 1] ??
+        "";
+      setSelectedDuration(savedDuration);
+
+      // Default colors are deterministic by add order, so rebuild them and layer
+      // the stored overrides (the only colors actually encoded) on top.
+      const restoredColors = {};
+      state.c.forEach((label, i) => {
+        restoredColors[parseCourseLabel(label).cleanCourseCode] =
+          defaultColorForIndex(i);
+      });
+      Object.assign(restoredColors, state.col || {});
+      restoreCourseColors(restoredColors);
+
+      setTimetables(result);
+    },
+    [resetToBlankSlate, showError, restoreCourseColors],
+  );
+
+  // Restore from a shared URL once on mount.
+  useEffect(() => {
+    const encoded = initialEncodedRef.current;
+    if (!encoded) return;
+    restoreFromUrlState(encoded);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <CourseDetailsProvider>
-      <CourseColorsProvider>
-        <div className="flex min-w-[350px] flex-col items-center">
-          <div className="w-full max-w-[1280px]">
-            <NavbarComponent />
-            <div className="grid grid-cols-1 justify-center md:grid-cols-12">
-              <div className="md:col-span-4">
-                <div className="mx-2 mt-2 md:mx-1">
-                  <InputFormTopComponent
-                    setTimetables={setTimetables}
-                    setSelectedDuration={setSelectedDuration}
-                    setDurations={setDurations}
-                    setSortOption={setSortOption}
+    <div className="flex min-w-[350px] flex-col items-center">
+      <div className="w-full max-w-[1280px]">
+        <NavbarComponent />
+        <div className="grid grid-cols-1 justify-center md:grid-cols-12">
+          <div className="md:col-span-4">
+            <div className="mx-2 mt-2 md:mx-1">
+              <InputFormTopComponent
+                setTimetables={setTimetables}
+                setSelectedDuration={setSelectedDuration}
+                setDurations={setDurations}
+                setSortOption={setSortOption}
+                addedCourses={addedCourses}
+                setAddedCourses={setAddedCourses}
+                timetableType={timetableType}
+                setTimetableType={setTimetableType}
+                term={term}
+                setTerm={setTerm}
+              />
+              {!isBelowMedium && (
+                <div className="mt-4">
+                  <InputFormBottomComponent
                     addedCourses={addedCourses}
                     setAddedCourses={setAddedCourses}
-                  />
-                  {!isBelowMedium && (
-                    <div className="mt-4">
-                      <InputFormBottomComponent
-                        addedCourses={addedCourses}
-                        setAddedCourses={setAddedCourses}
-                        setTimetables={setTimetables}
-                        timetables={timetables}
-                        durations={durations}
-                        sortOption={sortOption}
-                      />
-                    </div>
-                  )}
-                </div>
-              </div>
-              <div className="md:col-span-8">
-                <div className="mx-2 mt-0 sm:mt-2 md:mx-1">
-                  <CalendarComponent
-                    timetables={timetables}
                     setTimetables={setTimetables}
-                    selectedDuration={selectedDuration}
-                    setSelectedDuration={setSelectedDuration}
+                    timetables={timetables}
                     durations={durations}
                     sortOption={sortOption}
                   />
                 </div>
-              </div>
-              {isBelowMedium && (
-                <div className="md:col-span-12">
-                  <div className="mx-2 mt-0 sm:mt-2">
-                    <InputFormBottomComponent
-                      addedCourses={addedCourses}
-                      setAddedCourses={setAddedCourses}
-                      setTimetables={setTimetables}
-                      timetables={timetables}
-                      durations={durations}
-                      sortOption={sortOption}
-                    />
-                  </div>
-                </div>
               )}
             </div>
-            <IntroGuideWidget />
-            <ConflictDialog
-              open={conflictDialogOpen}
-              onClose={handlePinAndIgnoreConflict}
-              conflictInfo={conflictInfo}
-              onRemoveCourse={handleRemoveConflictCourse}
-            />
-            <FooterComponent />
           </div>
+          <div className="md:col-span-8">
+            <div className="mx-2 mt-0 sm:mt-2 md:mx-1">
+              <CalendarComponent
+                timetables={timetables}
+                setTimetables={setTimetables}
+                selectedDuration={selectedDuration}
+                setSelectedDuration={setSelectedDuration}
+                durations={durations}
+                sortOption={sortOption}
+                currentTimetableIndex={currentTimetableIndex}
+                setCurrentTimetableIndex={setCurrentTimetableIndex}
+                onTimeBlockChange={onTimeBlockChange}
+              />
+            </div>
+          </div>
+          {isBelowMedium && (
+            <div className="md:col-span-12">
+              <div className="mx-2 mt-0 sm:mt-2">
+                <InputFormBottomComponent
+                  addedCourses={addedCourses}
+                  setAddedCourses={setAddedCourses}
+                  setTimetables={setTimetables}
+                  timetables={timetables}
+                  durations={durations}
+                  sortOption={sortOption}
+                />
+              </div>
+            </div>
+          )}
         </div>
+        <IntroGuideWidget />
+        <ConflictDialog
+          open={conflictDialogOpen}
+          onClose={handlePinAndIgnoreConflict}
+          conflictInfo={conflictInfo}
+          onRemoveCourse={handleRemoveConflictCourse}
+        />
+        <FooterComponent />
+      </div>
+    </div>
+  );
+}
+
+// The page body lives inside the providers so it can read/restore course colors
+// (CourseColorsContext) alongside the timetable state it already owns.
+function GeneratorPage() {
+  return (
+    <CourseDetailsProvider>
+      <CourseColorsProvider>
+        <GeneratorPageContent />
       </CourseColorsProvider>
     </CourseDetailsProvider>
   );

--- a/src/pages/GeneratorPage.jsx
+++ b/src/pages/GeneratorPage.jsx
@@ -92,8 +92,7 @@ function GeneratorPageContent() {
     });
   }, []);
   const { enqueueSnackbar } = useSnackbar();
-  const { courseColors, restoreCourseColors } =
-    useContext(CourseColorsContext);
+  const { courseColors, restoreCourseColors } = useContext(CourseColorsContext);
   const [timetables, setTimetables] = useState([]);
   const [selectedDuration, setSelectedDuration] = useState("");
   const [durations, setDurations] = useState([]);
@@ -114,9 +113,9 @@ function GeneratorPageContent() {
   // strips ?s=, so we must read it before that happens.
   const initialEncodedRef = useRef(undefined);
   if (initialEncodedRef.current === undefined) {
-    initialEncodedRef.current = new URLSearchParams(
-      window.location.search,
-    ).get("s");
+    initialEncodedRef.current = new URLSearchParams(window.location.search).get(
+      "s",
+    );
   }
 
   // timeBlockEvents is a singleton, so mutations don't trigger React effects.


### PR DESCRIPTION
The URL bar now always encodes the timetable you're viewing. Opening that link or reloading restores everything with no backend. The courses are re-fetched, pins, blocked times, selected duration, and course colors are all reapplied, to show the exact timetable that was viewed with all the components pinned. 

In the event that a component is no longer offered from a saved timetable the link will reset to a blank slate and inform the user that their saved timetable is no longer being offered.

fflate is added as a new dependency, as it is used to in the process of compressing the timetable data to create the shortest urls possible.

A button to quickly copy the timetable link has also been added.